### PR TITLE
[Contract][Feat] Implement auth middleware

### DIFF
--- a/gateway-contract/contracts/alien-gateway/src/address_manager.rs
+++ b/gateway-contract/contracts/alien-gateway/src/address_manager.rs
@@ -1,37 +1,32 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
+use crate::contract_core;
+
 // Storage Keys
 #[contracttype]
 #[derive(Clone)]
 pub enum DataKey {
-    Owner,
     Address(Address),
     MasterAddress,
 }
 
 // Event Symbol
-const MASTER_SET: Symbol = symbol_short!("MASTER_SET");
+const MASTER_SET: Symbol = symbol_short!("MSTR_SET");
 
 pub struct AddressManager;
 
 impl AddressManager {
-    // Initialize contract with owner
+    // Initialize contract with owner (sets shared owner for auth middleware)
     pub fn init(env: Env, owner: Address) {
-        if env.storage().instance().has(&DataKey::Owner) {
+        if env.storage().instance().has(&contract_core::DataKey::Owner) {
             panic!("Already initialized");
         }
-        env.storage().instance().set(&DataKey::Owner, &owner);
+        env.storage().instance().set(&contract_core::DataKey::Owner, &owner);
     }
 
-    // Helper: check owner
+    // Helper: check owner via shared auth middleware
     fn require_owner(env: &Env) {
-        let owner: Address = env
-            .storage()
-            .instance()
-            .get(&DataKey::Owner)
-            .unwrap();
-
-        owner.require_auth();
+        contract_core::auth::require_owner(env);
     }
 
     // Helper: check address exists

--- a/gateway-contract/contracts/alien-gateway/src/address_manager.rs
+++ b/gateway-contract/contracts/alien-gateway/src/address_manager.rs
@@ -21,7 +21,9 @@ impl AddressManager {
         if env.storage().instance().has(&contract_core::DataKey::Owner) {
             panic!("Already initialized");
         }
-        env.storage().instance().set(&contract_core::DataKey::Owner, &owner);
+        env.storage()
+            .instance()
+            .set(&contract_core::DataKey::Owner, &owner);
     }
 
     // Helper: check owner via shared auth middleware
@@ -64,10 +66,8 @@ impl AddressManager {
             .set(&DataKey::MasterAddress, &address);
 
         // Emit Event
-        env.events().publish(
-            (MASTER_SET,),
-            address
-        );
+        #[allow(deprecated)]
+        env.events().publish((MASTER_SET,), address);
     }
 
     // Getter

--- a/gateway-contract/contracts/alien-gateway/src/contract_core/auth.rs
+++ b/gateway-contract/contracts/alien-gateway/src/contract_core/auth.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::{Address, Env};
+
+use super::DataKey;
+
+/// Requires that the current invoker is the contract owner. Use at the start of
+/// all state-changing (write) functions. No state change without auth.
+pub fn require_owner(env: &Env) {
+    let owner: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Owner)
+        .unwrap_or_else(|| panic!("Contract not initialized"));
+    owner.require_auth();
+}

--- a/gateway-contract/contracts/alien-gateway/src/contract_core/mod.rs
+++ b/gateway-contract/contracts/alien-gateway/src/contract_core/mod.rs
@@ -37,29 +37,21 @@ impl CoreContract {
             .set(&DataKey::CreatedAt, &env.ledger().timestamp());
 
         // Emit event
+        #[allow(deprecated)]
         env.events().publish((INIT_EVENT,), (username, owner));
     }
 
     // Getters
     pub fn get_username(env: Env) -> Symbol {
-        env.storage()
-            .instance()
-            .get(&DataKey::Username)
-            .unwrap()
+        env.storage().instance().get(&DataKey::Username).unwrap()
     }
 
     pub fn get_owner(env: Env) -> Address {
-        env.storage()
-            .instance()
-            .get(&DataKey::Owner)
-            .unwrap()
+        env.storage().instance().get(&DataKey::Owner).unwrap()
     }
 
     pub fn get_created_at(env: Env) -> u64 {
-        env.storage()
-            .instance()
-            .get(&DataKey::CreatedAt)
-            .unwrap()
+        env.storage().instance().get(&DataKey::CreatedAt).unwrap()
     }
 
     /// Transfer ownership to a new address. Caller must be current owner.

--- a/gateway-contract/contracts/alien-gateway/src/lib.rs
+++ b/gateway-contract/contracts/alien-gateway/src/lib.rs
@@ -1,6 +1,12 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
+pub mod contract_core;
+pub mod address_manager;
+
+pub use contract_core::CoreContract;
+pub use address_manager::AddressManager;
+
 #[contract]
 pub struct Contract;
 

--- a/gateway-contract/contracts/alien-gateway/src/lib.rs
+++ b/gateway-contract/contracts/alien-gateway/src/lib.rs
@@ -1,11 +1,11 @@
 #![no_std]
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
-pub mod contract_core;
 pub mod address_manager;
+pub mod contract_core;
 
-pub use contract_core::CoreContract;
 pub use address_manager::AddressManager;
+pub use contract_core::CoreContract;
 
 #[contract]
 pub struct Contract;

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_double_init_panics.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_double_init_panics.1.json
@@ -1,0 +1,104 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "INIT"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "symbol": "alien_user"
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_invalid_username_empty.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_invalid_username_empty.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_invalid_username_long.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_invalid_username_long.1.json
@@ -1,0 +1,76 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_master_assignment.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_master_assignment.1.json
@@ -1,0 +1,214 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Address"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MasterAddress"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_non_existent_address_fails.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_non_existent_address_fails.1.json
@@ -1,0 +1,123 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_ownership_transfer_new_owner_has_permissions.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_ownership_transfer_new_owner_has_permissions.1.json
@@ -1,0 +1,210 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ]
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CreatedAt"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Username"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "symbol": "user"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_ownership_transfer_old_owner_loses_permissions.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_ownership_transfer_old_owner_loses_permissions.1.json
@@ -1,0 +1,114 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CreatedAt"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Username"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "symbol": "user"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_successful_init.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_successful_init.1.json
@@ -1,0 +1,115 @@
+{
+  "generators": {
+    "address": 2,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "CreatedAt"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "u64": "0"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Username"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "symbol": "alien_user"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_switch_master.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_switch_master.1.json
@@ -1,0 +1,325 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Address"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Address"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MasterAddress"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "1033654523790656264"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "1033654523790656264"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "4837995959683129791"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "4837995959683129791"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_unauthorized_fails.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_unauthorized_fails.1.json
@@ -1,0 +1,90 @@
+{
+  "generators": {
+    "address": 4,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_write_with_auth_succeeds.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_write_with_auth_succeeds.1.json
@@ -1,0 +1,214 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    [],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "",
+              "args": []
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Address"
+                            },
+                            {
+                              "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "bool": true
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "MasterAddress"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                        }
+                      },
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "801925984706572462"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "801925984706572462"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": "5541220902715666415"
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": "5541220902715666415"
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          6311999
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/test_snapshots/test_write_without_auth_fails.1.json
+++ b/gateway-contract/contracts/alien-gateway/test_snapshots/test_write_without_auth_fails.1.json
@@ -1,0 +1,90 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0,
+    "mux_id": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 23,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": [
+                      {
+                        "key": {
+                          "vec": [
+                            {
+                              "symbol": "Owner"
+                            }
+                          ]
+                        },
+                        "val": {
+                          "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": []
+}

--- a/gateway-contract/contracts/alien-gateway/tests/test_address_manager.rs
+++ b/gateway-contract/contracts/alien-gateway/tests/test_address_manager.rs
@@ -1,0 +1,94 @@
+use soroban_sdk::{testutils::Address as _, Address, Env};
+use alien_gateway::{AddressManager, Contract};
+
+#[test]
+fn test_master_assignment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::register_address(env.clone(), user.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::set_master_stellar_address(env.clone(), user.clone());
+    });
+
+    let master = env.as_contract(&contract_id, || AddressManager::get_master(env.clone())).unwrap();
+    assert_eq!(master, user);
+}
+
+#[test]
+fn test_switch_master() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::register_address(env.clone(), user1.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::register_address(env.clone(), user2.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::set_master_stellar_address(env.clone(), user1.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::set_master_stellar_address(env.clone(), user2.clone());
+    });
+
+    let master = env.as_contract(&contract_id, || AddressManager::get_master(env.clone())).unwrap();
+    assert_eq!(master, user2);
+}
+
+#[test]
+#[should_panic(expected = "Address does not exist")]
+fn test_non_existent_address_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::set_master_stellar_address(env.clone(), user.clone());
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_unauthorized_fails() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Address::generate(&env);
+    let attacker = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+
+    env.as_contract(&contract_id, || {
+        owner.require_auth();
+        AddressManager::register_address(env.clone(), user.clone());
+    });
+
+    env.as_contract(&contract_id, || {
+        attacker.require_auth();
+        AddressManager::set_master_stellar_address(env.clone(), user.clone());
+    });
+}

--- a/gateway-contract/contracts/alien-gateway/tests/test_address_manager.rs
+++ b/gateway-contract/contracts/alien-gateway/tests/test_address_manager.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{testutils::Address as _, Address, Env};
 use alien_gateway::{AddressManager, Contract};
+use soroban_sdk::{testutils::Address as _, Address, Env};
 
 #[test]
 fn test_master_assignment() {
@@ -19,7 +19,9 @@ fn test_master_assignment() {
         AddressManager::set_master_stellar_address(env.clone(), user.clone());
     });
 
-    let master = env.as_contract(&contract_id, || AddressManager::get_master(env.clone())).unwrap();
+    let master = env
+        .as_contract(&contract_id, || AddressManager::get_master(env.clone()))
+        .unwrap();
     assert_eq!(master, user);
 }
 
@@ -48,7 +50,9 @@ fn test_switch_master() {
         AddressManager::set_master_stellar_address(env.clone(), user2.clone());
     });
 
-    let master = env.as_contract(&contract_id, || AddressManager::get_master(env.clone())).unwrap();
+    let master = env
+        .as_contract(&contract_id, || AddressManager::get_master(env.clone()))
+        .unwrap();
     assert_eq!(master, user2);
 }
 

--- a/gateway-contract/contracts/alien-gateway/tests/test_auth.rs
+++ b/gateway-contract/contracts/alien-gateway/tests/test_auth.rs
@@ -1,0 +1,91 @@
+//! Auth middleware integration tests.
+//! - Write without auth fails
+//! - Write with auth succeeds
+//! - Ownership transfer updates permissions
+
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+use alien_gateway::{AddressManager, Contract, CoreContract};
+
+#[test]
+#[should_panic]
+fn test_write_without_auth_fails() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let other = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        other.require_auth();
+        AddressManager::register_address(env.clone(), other.clone());
+    });
+}
+
+#[test]
+fn test_write_with_auth_succeeds() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::register_address(env.clone(), user.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::set_master_stellar_address(env.clone(), user.clone());
+    });
+
+    let master = env.as_contract(&contract_id, || AddressManager::get_master(env.clone())).unwrap();
+    assert_eq!(master, user);
+}
+
+#[test]
+fn test_ownership_transfer_new_owner_has_permissions() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let user = Symbol::new(&env, "user");
+
+    env.as_contract(&contract_id, || {
+        CoreContract::init(env.clone(), user.clone(), owner.clone());
+        assert_eq!(CoreContract::get_owner(env.clone()), owner);
+    });
+    env.as_contract(&contract_id, || {
+        CoreContract::transfer_ownership(env.clone(), new_owner.clone());
+        assert_eq!(CoreContract::get_owner(env.clone()), new_owner);
+    });
+    env.as_contract(&contract_id, || {
+        CoreContract::transfer_ownership(env.clone(), owner.clone());
+        assert_eq!(CoreContract::get_owner(env.clone()), owner);
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_ownership_transfer_old_owner_loses_permissions() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let user = Symbol::new(&env, "user");
+
+    env.as_contract(&contract_id, || {
+        CoreContract::init(env.clone(), user.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        owner.require_auth();
+        CoreContract::transfer_ownership(env.clone(), new_owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        owner.require_auth();
+        CoreContract::transfer_ownership(env.clone(), owner.clone());
+    });
+}

--- a/gateway-contract/contracts/alien-gateway/tests/test_auth.rs
+++ b/gateway-contract/contracts/alien-gateway/tests/test_auth.rs
@@ -3,8 +3,8 @@
 //! - Write with auth succeeds
 //! - Ownership transfer updates permissions
 
-use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
 use alien_gateway::{AddressManager, Contract, CoreContract};
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
 
 #[test]
 #[should_panic]
@@ -41,7 +41,9 @@ fn test_write_with_auth_succeeds() {
         AddressManager::set_master_stellar_address(env.clone(), user.clone());
     });
 
-    let master = env.as_contract(&contract_id, || AddressManager::get_master(env.clone())).unwrap();
+    let master = env
+        .as_contract(&contract_id, || AddressManager::get_master(env.clone()))
+        .unwrap();
     assert_eq!(master, user);
 }
 

--- a/gateway-contract/contracts/alien-gateway/tests/test_core.rs
+++ b/gateway-contract/contracts/alien-gateway/tests/test_core.rs
@@ -1,0 +1,59 @@
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
+use alien_gateway::{Contract, CoreContract};
+
+#[test]
+fn test_successful_init() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Symbol::new(&env, "alien_user");
+
+    env.as_contract(&contract_id, || {
+        CoreContract::init(env.clone(), user.clone(), owner.clone());
+    });
+
+    env.as_contract(&contract_id, || {
+        assert_eq!(CoreContract::get_username(env.clone()), user);
+        assert_eq!(CoreContract::get_owner(env.clone()), owner);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Contract already initialized")]
+fn test_double_init_panics() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Symbol::new(&env, "alien_user");
+
+    env.as_contract(&contract_id, || {
+        CoreContract::init(env.clone(), user.clone(), owner.clone());
+        CoreContract::init(env.clone(), user.clone(), owner);
+    });
+}
+
+#[test]
+#[should_panic(expected = "Username cannot be empty")]
+fn test_invalid_username_empty() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Symbol::new(&env, "");
+
+    env.as_contract(&contract_id, || {
+        CoreContract::init(env.clone(), user, owner);
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_username_long() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Symbol::new(&env, "this_username_is_way_more_than_32_characters");
+
+    env.as_contract(&contract_id, || {
+        CoreContract::init(env.clone(), user, owner);
+    });
+}

--- a/gateway-contract/contracts/alien-gateway/tests/test_core.rs
+++ b/gateway-contract/contracts/alien-gateway/tests/test_core.rs
@@ -1,5 +1,5 @@
-use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
 use alien_gateway::{Contract, CoreContract};
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
 
 #[test]
 fn test_successful_init() {

--- a/gateway-contract/tests/integration/test_core.rs
+++ b/gateway-contract/tests/integration/test_core.rs
@@ -1,40 +1,45 @@
-use soroban_sdk::{testutils::Address as _, Env, Symbol};
+use soroban_sdk::{testutils::Address as _, Address, Env, Symbol};
 use alien_gateway::CoreContract;
 
 #[test]
 fn test_successful_init() {
     let env = Env::default();
+    let owner = Address::generate(&env);
     let user = Symbol::new(&env, "alien_user");
 
-    CoreContract::init(env.clone(), user.clone());
+    CoreContract::init(env.clone(), user.clone(), owner.clone());
 
     assert_eq!(CoreContract::get_username(env.clone()), user);
+    assert_eq!(CoreContract::get_owner(env.clone()), owner);
 }
 
 #[test]
 #[should_panic(expected = "Contract already initialized")]
 fn test_double_init_panics() {
     let env = Env::default();
+    let owner = Address::generate(&env);
     let user = Symbol::new(&env, "alien_user");
 
-    CoreContract::init(env.clone(), user.clone());
-    CoreContract::init(env.clone(), user.clone());
+    CoreContract::init(env.clone(), user.clone(), owner.clone());
+    CoreContract::init(env.clone(), user.clone(), owner);
 }
 
 #[test]
-#[should_panic]
+#[should_panic(expected = "Username cannot be empty")]
 fn test_invalid_username_empty() {
     let env = Env::default();
+    let owner = Address::generate(&env);
     let user = Symbol::new(&env, "");
 
-    CoreContract::init(env.clone(), user);
+    CoreContract::init(env.clone(), user, owner);
 }
 
 #[test]
 #[should_panic]
 fn test_invalid_username_long() {
     let env = Env::default();
+    let owner = Address::generate(&env);
     let user = Symbol::new(&env, "this_username_is_way_more_than_32_characters");
 
-    CoreContract::init(env.clone(), user);
+    CoreContract::init(env.clone(), user, owner);
 }


### PR DESCRIPTION
## Description

Implements auth middleware so all state-changing functions are gated by owner auth. No state change is allowed without the stored owner having authorized the call.

## Changes

### Auth module
- **`contract_core/auth.rs`**: Added `require_owner(env: &Env)` which loads the contract owner from storage and calls `owner.require_auth()`.
- Shared across Core and AddressManager so a single middleware protects all writes.

### Core (`contract_core`)
- **`init(env, username, owner: Address)`**: Now takes an explicit `owner` (replacing `env.invoker()` for SDK compatibility). Still the only place that sets the shared owner; no auth on init.
- **`transfer_ownership(env, new_owner)`**: New write that calls `auth::require_owner(&env)` then updates the stored owner.
- Username validation simplified for no_std (empty check only; length capped by `Symbol`).

### AddressManager
- Replaced local `require_owner` with **`contract_core::auth::require_owner(env)`**.
- **`init`** sets **`contract_core::DataKey::Owner`** so Core and AddressManager share the same owner and auth.
- **`register_address`** and **`set_master_stellar_address`** continue to call the shared auth at the start of each write.

### Structure
- Renamed `core` to **`contract_core`** to avoid clashing with Rust’s `core`.
- **`contract_core`** is a module with `mod.rs` (Core + DataKey) and **`auth.rs`** (auth middleware).
- **`lib.rs`** wires and re-exports `CoreContract` and `AddressManager`.

### Tests
- **`contracts/alien-gateway/tests/test_auth.rs`** (new):
  - Write without auth fails (non-owner cannot perform writes).
  - Write with auth succeeds (owner can register and set master).
  - Ownership transfer: new owner gains permissions, old owner loses them.
- **`test_core.rs`** and **`test_address_manager.rs`** moved under **`contracts/alien-gateway/tests/`** and updated to use `env.as_contract()` and the new `init(env, username, owner)` signature.

## Acceptance criteria
- [x] No state change without auth (middleware used on all write paths).
- [x] Middleware used across modules (Core and AddressManager use `contract_core::auth::require_owner`).
- [x] Tests pass (`cargo test`).
- [x] CI passes (`stellar contract build` + `cargo test`).

Closes #13