### PR TITLE
feat(address_manager): add_stellar_address with label, auth, and duplicate prevention

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 pr_body.md
+test_snapshots/

--- a/gateway-contract/contracts/alien-gateway/src/address_manager.rs
+++ b/gateway-contract/contracts/alien-gateway/src/address_manager.rs
@@ -1,6 +1,7 @@
 use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 use crate::contract_core;
+use crate::types::AddressMetadata;
 
 // Storage Keys
 #[contracttype]
@@ -8,10 +9,12 @@ use crate::contract_core;
 pub enum DataKey {
     Address(Address),
     MasterAddress,
+    StellarAddress(Address),
 }
 
-// Event Symbol
+// Event Symbols
 const MASTER_SET: Symbol = symbol_short!("MSTR_SET");
+const ADDR_ADDED: Symbol = symbol_short!("ADDR_ADD");
 
 pub struct AddressManager;
 
@@ -73,5 +76,32 @@ impl AddressManager {
     // Getter
     pub fn get_master(env: Env) -> Option<Address> {
         env.storage().instance().get(&DataKey::MasterAddress)
+    }
+
+    // Add a Stellar address with a label. Owner-only. Prevents duplicates.
+    pub fn add_stellar_address(env: Env, address: Address, label: Symbol) {
+        Self::require_owner(&env);
+        if env
+            .storage()
+            .instance()
+            .has(&DataKey::StellarAddress(address.clone()))
+        {
+            panic!("Address already exists");
+        }
+        let metadata = AddressMetadata {
+            label: label.clone(),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::StellarAddress(address.clone()), &metadata);
+        #[allow(deprecated)]
+        env.events().publish((ADDR_ADDED,), (address, label));
+    }
+
+    // Retrieve metadata for a registered Stellar address.
+    pub fn get_stellar_address(env: Env, address: Address) -> Option<AddressMetadata> {
+        env.storage()
+            .instance()
+            .get(&DataKey::StellarAddress(address))
     }
 }

--- a/gateway-contract/contracts/alien-gateway/src/lib.rs
+++ b/gateway-contract/contracts/alien-gateway/src/lib.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
 
 pub mod address_manager;
 pub mod contract_core;
+pub mod types;
 
 pub use address_manager::AddressManager;
 pub use contract_core::CoreContract;

--- a/gateway-contract/contracts/alien-gateway/src/types.rs
+++ b/gateway-contract/contracts/alien-gateway/src/types.rs
@@ -1,0 +1,7 @@
+use soroban_sdk::{contracttype, Symbol};
+
+#[contracttype]
+#[derive(Clone)]
+pub struct AddressMetadata {
+    pub label: Symbol,
+}

--- a/gateway-contract/contracts/alien-gateway/tests/test_address_manager.rs
+++ b/gateway-contract/contracts/alien-gateway/tests/test_address_manager.rs
@@ -1,5 +1,5 @@
 use alien_gateway::{AddressManager, Contract};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{symbol_short, testutils::Address as _, Address, Env};
 
 #[test]
 fn test_master_assignment() {
@@ -95,4 +95,109 @@ fn test_unauthorized_fails() {
         attacker.require_auth();
         AddressManager::set_master_stellar_address(env.clone(), user.clone());
     });
+}
+
+// --- add_stellar_address tests ---
+
+#[test]
+fn test_add_stellar_address_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Address::generate(&env);
+    let label = symbol_short!("wallet1");
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::add_stellar_address(env.clone(), user.clone(), label.clone());
+    });
+
+    let metadata = env
+        .as_contract(&contract_id, || {
+            AddressManager::get_stellar_address(env.clone(), user.clone())
+        })
+        .unwrap();
+    assert_eq!(metadata.label, label);
+}
+
+#[test]
+#[should_panic(expected = "Address already exists")]
+fn test_add_stellar_address_duplicate_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user = Address::generate(&env);
+    let label = symbol_short!("wallet1");
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::add_stellar_address(env.clone(), user.clone(), label.clone());
+    });
+    // Second add of same address should panic
+    env.as_contract(&contract_id, || {
+        AddressManager::add_stellar_address(env.clone(), user.clone(), label.clone());
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_add_stellar_address_unauthorized() {
+    let env = Env::default();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let label = symbol_short!("hack");
+
+    env.mock_all_auths();
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+
+    // No mock_all_auths for attacker — auth will fail
+    env.set_auths(&[]);
+    env.as_contract(&contract_id, || {
+        AddressManager::add_stellar_address(env.clone(), attacker.clone(), label.clone());
+    });
+}
+
+#[test]
+fn test_add_stellar_address_metadata_stored() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Contract, ());
+    let owner = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+    let label1 = symbol_short!("primary");
+    let label2 = symbol_short!("secondary");
+
+    env.as_contract(&contract_id, || {
+        AddressManager::init(env.clone(), owner.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::add_stellar_address(env.clone(), user1.clone(), label1.clone());
+    });
+    env.as_contract(&contract_id, || {
+        AddressManager::add_stellar_address(env.clone(), user2.clone(), label2.clone());
+    });
+
+    let meta1 = env
+        .as_contract(&contract_id, || {
+            AddressManager::get_stellar_address(env.clone(), user1.clone())
+        })
+        .unwrap();
+    let meta2 = env
+        .as_contract(&contract_id, || {
+            AddressManager::get_stellar_address(env.clone(), user2.clone())
+        })
+        .unwrap();
+
+    assert_eq!(meta1.label, label1);
+    assert_eq!(meta2.label, label2);
 }


### PR DESCRIPTION
Closes #10

## Summary

- Introduces `contracts/core/src/types.rs` with `AddressMetadata { label: Symbol }` struct tagged with `#[contracttype]`
- Adds `add_stellar_address(env, address, label)` to `AddressManager`:
  - Enforces owner auth via shared `contract_core::auth::require_owner`
  - Rejects duplicate addresses (`"Address already exists"` panic)
  - Stores `AddressMetadata` keyed by `DataKey::StellarAddress(address)`
  - Emits `AddressAdded` event (`ADDR_ADD` symbol)
- Adds `get_stellar_address(env, address) -> Option<AddressMetadata>` getter
- Registers `pub mod types` in `lib.rs`
- Ignores auto-generated `test_snapshots/` in `.gitignore`

## Acceptance Criteria

- [x] Address stored
- [x] Duplicate blocked
- [x] Auth enforced
- [x] Tests pass

## Test Plan

- `test_add_stellar_address_success` — address stored on valid owner call
- `test_add_stellar_address_duplicate_rejected` — second add of same address panics with `"Address already exists"`
- `test_add_stellar_address_unauthorized` — call without auth panics
- `test_add_stellar_address_metadata_stored` — label retrieved correctly per address

```
cargo fmt && cargo clippy -- -D warnings && cargo test && cargo build --release
```
All 17 tests pass, zero clippy warnings, release build successful.