### PR TITLE
refactor: centralise all event definitions in events.rs

### DIFF
--- a/gateway-contract/contracts/core_contract/src/events.rs
+++ b/gateway-contract/contracts/core_contract/src/events.rs
@@ -1,0 +1,16 @@
+#![allow(dead_code)]
+
+use soroban_sdk::{symbol_short, Symbol};
+
+pub const INIT_EVENT: Symbol = symbol_short!("INIT");
+pub const TRANSFER_EVENT: Symbol = symbol_short!("TRANSFER");
+pub const REGISTER_EVENT: Symbol = symbol_short!("REGISTER");
+pub const ROOT_UPDATED: Symbol = symbol_short!("ROOT_UPD");
+pub const MASTER_SET: Symbol = symbol_short!("MSTR_SET");
+pub const ADDR_ADDED: Symbol = symbol_short!("ADDR_ADD");
+pub const CHAIN_ADD: Symbol = symbol_short!("CHAIN_ADD");
+pub const CHAIN_REM: Symbol = symbol_short!("CHAIN_REM");
+pub const VAULT_CREATE: Symbol = symbol_short!("VAULT_CRT");
+pub const DEPOSIT: Symbol = symbol_short!("DEPOSIT");
+pub const WITHDRAW: Symbol = symbol_short!("WITHDRAW");
+pub const SCHED_PAY: Symbol = symbol_short!("SCHED_PAY");

--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -1,5 +1,7 @@
 #![no_std]
 
+pub mod events;
+
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, panic_with_error, Address, BytesN, Env,
 };

--- a/gateway-contract/contracts/core_contract/src/registration.rs
+++ b/gateway-contract/contracts/core_contract/src/registration.rs
@@ -1,4 +1,5 @@
-use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Symbol};
+use soroban_sdk::{contracttype, Address, BytesN, Env};
+use crate::events::REGISTER_EVENT;
 
 // Storage Keys
 #[contracttype]
@@ -6,9 +7,6 @@ use soroban_sdk::{contracttype, symbol_short, Address, BytesN, Env, Symbol};
 pub enum DataKey {
     Commitment(BytesN<32>),
 }
-
-// Events
-const REGISTER_EVENT: Symbol = symbol_short!("REGISTER");
 
 pub struct Registration;
 

--- a/gateway-contract/contracts/core_contract/src/smt_root.rs
+++ b/gateway-contract/contracts/core_contract/src/smt_root.rs
@@ -1,6 +1,7 @@
-use soroban_sdk::{contracttype, symbol_short, BytesN, Env, Symbol};
+use soroban_sdk::{contracttype, BytesN, Env};
 
 use crate::contract_core;
+use crate::events::ROOT_UPDATED;
 
 // Storage Keys
 #[contracttype]
@@ -8,9 +9,6 @@ use crate::contract_core;
 pub enum DataKey {
     SmtRoot,
 }
-
-// Event
-const ROOT_UPDATED: Symbol = symbol_short!("ROOT_UPD");
 
 pub struct SmtRoot;
 


### PR DESCRIPTION
closes  #67 

created 

events.rs
 in core_contract exposing all required Symbol constants (INIT_EVENT, TRANSFER_EVENT, REGISTER_EVENT, ROOT_UPDATED, MASTER_SET, ADDR_ADDED, CHAIN_ADD, CHAIN_REM, VAULT_CREATE, DEPOSIT, WITHDRAW, SCHED_PAY).
Cleaned up inline symbol_short! definitions in 

registration.rs
 and 

smt_root.rs
 and replaced them with crate::events::* imports.
Updated 

lib.rs
 to expose the events module publicly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated event identifier definitions into a centralized module to improve code organization and maintainability across contract components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->