### PR TITLE
feat(zk): add Merkle non-inclusion proof circuit (#7)

### DIFF
--- a/zk/circuits/merkle/merkle_non_inclusion.circom
+++ b/zk/circuits/merkle/merkle_non_inclusion.circom
@@ -1,0 +1,45 @@
+pragma circom 2.0.0;
+
+include "path_calculator.circom";
+
+// MerkleNonInclusionProof
+//
+// Proves that a username slot is EMPTY in the Sparse Merkle Tree, i.e.
+// the leaf at the given path is 0, without revealing the username itself.
+//
+// The prover supplies the Merkle path to the target slot and the current
+// root. The circuit recomputes the root from leaf = 0 and asserts it
+// matches the public root, proving the slot is unoccupied.
+//
+// Public inputs  : root
+// Private inputs : merklePathSiblings, merklePathIndices
+// Public output  : out_root  (echoes root, for on-chain anchoring)
+
+template MerkleNonInclusionProof(levels) {
+
+    // ── Private inputs ───────────────────────────────────────────────────────
+    signal input merklePathSiblings[levels];  // sibling at each tree level
+    signal input merklePathIndices[levels];   // 0 = left child, 1 = right child
+
+    // ── Public inputs ────────────────────────────────────────────────────────
+    signal input root;  // current SMT root
+
+    // ── Public output ────────────────────────────────────────────────────────
+    signal output out_root;
+
+    // ── Verify the slot is empty ─────────────────────────────────────────────
+    // Walk up from leaf = 0 (empty slot) along the provided path.
+    // The computed root must equal the public root, proving the slot is empty.
+    component calc = PathCalculator(levels);
+    calc.leaf <== 0;
+    for (var i = 0; i < levels; i++) {
+        calc.pathElements[i] <== merklePathSiblings[i];
+        calc.pathIndices[i]  <== merklePathIndices[i];
+    }
+
+    calc.root === root;
+
+    out_root <== root;
+}
+
+component main {public [root]} = MerkleNonInclusionProof(20);

--- a/zk/package.json
+++ b/zk/package.json
@@ -4,8 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-  "test": "node tests/test_update_proof.js",
+  "test": "node tests/test_update_proof.js && node tests/test_non_inclusion_proof.js",
   "test:update_proof": "node tests/test_update_proof.js",
+  "test:non_inclusion": "node tests/test_non_inclusion_proof.js",
 
   "setup": "cd scripts && chmod +x trusted-setup.sh && ./trusted-setup.sh",
 
@@ -18,6 +19,10 @@
   "compile:merkle_update": "mkdir -p build/merkle_update/wasm && circom circuits/merkle_update.circom --r1cs --sym -o build/merkle_update -l node_modules && circom circuits/merkle_update.circom --wasm -o build/merkle_update/wasm -l node_modules",
 
   "compile:merkle_update_proof": "mkdir -p build/merkle_update_proof/wasm && circom circuits/merkle/merkle_update_proof.circom --r1cs --sym -o build/merkle_update_proof -l node_modules && circom circuits/merkle/merkle_update_proof.circom --wasm -o build/merkle_update_proof/wasm -l node_modules",
+
+  "compile:merkle_non_inclusion": "mkdir -p build/merkle_non_inclusion/wasm && circom circuits/merkle/merkle_non_inclusion.circom --r1cs --sym -o build/merkle_non_inclusion -l node_modules && circom circuits/merkle/merkle_non_inclusion.circom --wasm -o build/merkle_non_inclusion/wasm -l node_modules",
+
+  "setup:merkle_non_inclusion": "node -e \"const s=require('snarkjs');const p=require('path');(async()=>{const ptau=p.join('build','pot20_final.ptau');const r1cs=p.join('build','merkle_non_inclusion','merkle_non_inclusion.r1cs');const zkey0=p.join('build','merkle_non_inclusion','merkle_non_inclusion_0.zkey');const zkeyF=p.join('build','merkle_non_inclusion','merkle_non_inclusion_final.zkey');const vkey=p.join('build','merkle_non_inclusion','verification_key.json');await s.zKey.newZKey(r1cs,ptau,zkey0);await s.zKey.beacon(zkey0,zkeyF,'0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f',10);const vk=await s.zKey.exportVerificationKey(zkeyF);require('fs').writeFileSync(vkey,JSON.stringify(vk,null,2));console.log('setup done');})()\"",
 
   "compile:username_merkle": "mkdir -p build/username_merkle/wasm && circom circuits/username_merkle.circom --r1cs --sym -o build/username_merkle -l node_modules && circom circuits/username_merkle.circom --wasm -o build/username_merkle/wasm -l node_modules"
 

--- a/zk/scripts/compile.cmd
+++ b/zk/scripts/compile.cmd
@@ -22,6 +22,9 @@ echo.
 call :compile_circuit "merkle_inclusion" "merkle\merkle_inclusion.circom"
 if errorlevel 1 goto :error
 
+call :compile_circuit "merkle_non_inclusion" "merkle\merkle_non_inclusion.circom"
+if errorlevel 1 goto :error
+
 call :compile_circuit "merkle_update" "merkle_update.circom"
 if errorlevel 1 goto :error
 

--- a/zk/scripts/compile.sh
+++ b/zk/scripts/compile.sh
@@ -16,6 +16,7 @@ NODE_MODULES="$ZK_DIR/node_modules"
 # Circuits to compile: "name|circom_path"
 CIRCUITS=(
   "merkle_inclusion|merkle/merkle_inclusion.circom"
+  "merkle_non_inclusion|merkle/merkle_non_inclusion.circom"
   "merkle_update|merkle_update.circom"
   "merkle_update_proof|merkle/merkle_update_proof.circom"
   "username_merkle|username_merkle.circom"

--- a/zk/tests/test_non_inclusion_proof.js
+++ b/zk/tests/test_non_inclusion_proof.js
@@ -1,0 +1,127 @@
+"use strict";
+
+/**
+ * test_non_inclusion_proof.js
+ *
+ * Witness generation + Groth16 proof test for MerkleNonInclusionProof.
+ *
+ * Prerequisites (run from zk/):
+ *   npm run compile:merkle_non_inclusion
+ *   npm run setup:merkle_non_inclusion
+ *
+ * Run:
+ *   node tests/test_non_inclusion_proof.js
+ */
+
+const path    = require("path");
+const assert  = require("assert");
+const snarkjs = require("snarkjs");
+const { buildPoseidon } = require("circomlibjs");
+
+const CIRCUIT   = "merkle_non_inclusion";
+const BUILD_DIR = path.join(__dirname, "..", "build", CIRCUIT);
+const WASM_PATH = path.join(BUILD_DIR, "wasm", `${CIRCUIT}_js`, `${CIRCUIT}.wasm`);
+const ZKEY_PATH = path.join(BUILD_DIR, `${CIRCUIT}_final.zkey`);
+const VKEY_PATH = path.join(BUILD_DIR, "verification_key.json");
+
+const LEVELS = 20;
+
+// Build empty-subtree hash table: emptyHashes[i] = root of all-zero tree of height i
+async function buildEmptyHashes(poseidon, depth) {
+    const F = poseidon.F;
+    const h = [BigInt(0)];
+    for (let i = 0; i < depth; i++) {
+        h.push(F.toObject(poseidon([h[i], h[i]])));
+    }
+    return h;
+}
+
+// Recompute root from leaf + path (mirrors PathCalculator / BitSelector logic)
+function computeRoot(poseidon, leaf, siblings, indices) {
+    const F = poseidon.F;
+    let cur = leaf;
+    for (let i = 0; i < siblings.length; i++) {
+        const [left, right] = indices[i] === 0
+            ? [cur, siblings[i]]
+            : [siblings[i], cur];
+        cur = F.toObject(poseidon([left, right]));
+    }
+    return cur;
+}
+
+async function runTests() {
+    const poseidon    = await buildPoseidon();
+    const emptyHashes = await buildEmptyHashes(poseidon, LEVELS);
+
+    // All-empty tree: position 0, every index = 0, sibling = empty subtree of that height
+    const siblings = emptyHashes.slice(0, LEVELS);
+    const indices  = new Array(LEVELS).fill(0);
+    const root     = computeRoot(poseidon, BigInt(0), siblings, indices);
+
+    assert.strictEqual(
+        root.toString(),
+        emptyHashes[LEVELS].toString(),
+        "computed root should match all-empty tree root"
+    );
+
+    const input = {
+        merklePathSiblings: siblings.map(x => x.toString()),
+        merklePathIndices:  indices.map(x => x.toString()),
+        root:               root.toString(),
+    };
+
+    // ── Test 1: valid non-inclusion proof ─────────────────────────────────────
+    process.stdout.write("\n── Test 1: valid non-inclusion proof ───────────────────────\n");
+    {
+        const { proof, publicSignals } = await snarkjs.groth16.fullProve(
+            input, WASM_PATH, ZKEY_PATH
+        );
+        const vKey  = require(VKEY_PATH);
+        const valid = await snarkjs.groth16.verify(vKey, publicSignals, proof);
+
+        assert.ok(valid, "proof should verify");
+        assert.strictEqual(publicSignals[0], root.toString(), "out_root must equal root");
+        process.stdout.write("  ✔  proof generated and verified\n");
+        process.stdout.write(`  ✔  out_root = ${publicSignals[0]}\n`);
+    }
+
+    // ── Test 2: occupied slot → witness generation must fail ──────────────────
+    // Simulate a slot that holds a real leaf (non-zero) by computing the root
+    // from a non-zero leaf and passing that as the public root while keeping
+    // the path pointing to leaf = 0. The constraint calc.root === root fails.
+    process.stdout.write("\n── Test 2: occupied slot rejected ──────────────────────────\n");
+    {
+        const fakeLeaf = poseidon.F.toObject(poseidon([BigInt(99)]));
+        const occupiedRoot = computeRoot(poseidon, fakeLeaf, siblings, indices);
+        const badInput = { ...input, root: occupiedRoot.toString() };
+        let threw = false;
+        try {
+            await snarkjs.groth16.fullProve(badInput, WASM_PATH, ZKEY_PATH);
+        } catch {
+            threw = true;
+        }
+        assert.ok(threw, "witness generation should fail when slot is occupied");
+        process.stdout.write("  ✔  occupied slot correctly rejected\n");
+    }
+
+    // ── Test 3: tampered root → witness generation must fail ──────────────────
+    process.stdout.write("\n── Test 3: tampered root rejected ──────────────────────────\n");
+    {
+        const badInput = { ...input, root: (root + BigInt(1)).toString() };
+        let threw = false;
+        try {
+            await snarkjs.groth16.fullProve(badInput, WASM_PATH, ZKEY_PATH);
+        } catch {
+            threw = true;
+        }
+        assert.ok(threw, "witness generation should fail for a tampered root");
+        process.stdout.write("  ✔  tampered root correctly rejected\n");
+    }
+
+    process.stdout.write("\n══ All tests passed ══\n\n");
+}
+
+runTests().catch(err => {
+    process.stderr.write(`\n✘  Test failed: ${err.message ?? err}\n`);
+    process.exit(1);
+});


### PR DESCRIPTION
Implements the Sparse Merkle Tree non-membership proof circuit, closing roadmap issue #7.

Changes:
- zk/circuits/merkle/merkle_non_inclusion.circom MerkleNonInclusionProof(20): walks up from leaf=0 along the prover-supplied path and asserts the computed root equals the public root, proving the target slot is unoccupied. Reuses PathCalculator (and its BitSelector binary constraints) so pathIndices soundness is already enforced.

- zk/tests/test_non_inclusion_proof.js Three test vectors: 1. valid empty-slot proof generates and verifies 2. occupied slot (non-zero leaf) rejected at witness generation 3. tampered public root rejected at witness generation

- zk/scripts/compile.sh / compile.cmd merkle_non_inclusion added to the build list.

- zk/package.json compile:merkle_non_inclusion, setup:merkle_non_inclusion, test:non_inclusion scripts added; default test script runs both update_proof and non_inclusion suites.

closes #27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Merkle tree non-inclusion proofs, enabling cryptographic verification that specific values do not exist within a Merkle tree. This expands privacy-preserving proof capabilities for applications requiring proof of absence.

* **Tests**
  * Added comprehensive test coverage for non-inclusion proof generation and verification, including edge cases and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->