### PR TITLE
feat(auction): Define all error variants for the auction contract.

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/errors.rs
+++ b/gateway-contract/contracts/auction_contract/src/errors.rs
@@ -3,9 +3,13 @@ use soroban_sdk::contracterror;
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
-pub enum Error {
+pub enum AuctionError {
     NotWinner = 1,
     AlreadyClaimed = 2,
     NotClosed = 3,
     NoFactoryContract = 4,
+    Unauthorized = 5,
+    InvalidState = 6,
+    BidTooLow = 7,
+    AuctionNotOpen = 8,
 }

--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -18,22 +18,22 @@ impl AuctionContract {
         env: Env,
         username_hash: BytesN<32>,
         claimer: Address,
-    ) -> Result<(), crate::errors::Error> {
+    ) -> Result<(), crate::errors::AuctionError> {
         claimer.require_auth();
 
         let status = storage::get_status(&env);
 
         if status == types::AuctionStatus::Claimed {
-            return Err(crate::errors::Error::AlreadyClaimed);
+            return Err(crate::errors::AuctionError::AlreadyClaimed);
         }
 
         if status != types::AuctionStatus::Closed {
-            return Err(crate::errors::Error::NotClosed);
+            return Err(crate::errors::AuctionError::NotClosed);
         }
 
         let highest_bidder = storage::get_highest_bidder(&env);
         if !highest_bidder.map(|h| h == claimer).unwrap_or(false) {
-            return Err(crate::errors::Error::NotWinner);
+            return Err(crate::errors::AuctionError::NotWinner);
         }
 
         // Set status to Claimed
@@ -42,10 +42,10 @@ impl AuctionContract {
         // Call factory_contract.deploy_username(username_hash, claimer)
         let factory = storage::get_factory_contract(&env);
         if factory.is_none() {
-            return Err(crate::errors::Error::NoFactoryContract);
+            return Err(crate::errors::AuctionError::NoFactoryContract);
         }
 
-        let factory_addr = factory.ok_or(crate::errors::Error::NoFactoryContract)?;
+        let factory_addr = factory.ok_or(crate::errors::AuctionError::NoFactoryContract)?;
         env.invoke_contract::<()>(
             &factory_addr,
             &Symbol::new(&env, "deploy_username"),


### PR DESCRIPTION
Defines `AuctionError` with 8 variants in `errors.rs`, preserving existing discriminants (1–4) and adding 5–8. Updated usages in `lib.rs`. Build and tests pass.

**Checklist:**
- [x] 8 error variants defined  
- [x] Correct attributes applied  
- [x] Imported and used in lib.rs  
- [x] Build passes  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced error handling in auction operations with more specific error types for scenarios like unauthorized access, invalid state, insufficient bid amounts, and closed auctions.

Closes #93
<!-- end of auto-generated comment: release notes by coderabbit.ai -->