### PR TITLE
feat(contract): Username to Address Resolver (resolve_stellar entry point)

### DIFF
--- a/gateway-contract/contracts/core_contract/src/errors.rs
+++ b/gateway-contract/contracts/core_contract/src/errors.rs
@@ -8,6 +8,8 @@ pub enum CoreError {
     NotFound = 1,
     /// The SMT root has not been set yet.
     RootNotSet = 2,
+    /// The username is registered but has no primary Stellar address linked.
+    NoAddressLinked = 3,
 }
 
 #[contracterror]

--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -90,4 +90,45 @@ impl Contract {
     ) -> Option<Bytes> {
         AddressManager::get_chain_address(env, username_hash, chain)
     }
+
+    /// Link a primary Stellar address to a registered username hash.
+    /// Only the registered owner of the commitment may call this.
+    pub fn add_stellar_address(
+        env: Env,
+        caller: Address,
+        username_hash: BytesN<32>,
+        stellar_address: Address,
+    ) {
+        caller.require_auth();
+
+        // Verify the commitment is registered and caller is the owner.
+        let owner = Registration::get_owner(env.clone(), username_hash.clone())
+            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
+
+        if owner != caller {
+            panic_with_error!(&env, CoreError::NotFound);
+        }
+
+        env.storage().persistent().set(
+            &storage::DataKey::StellarAddress(username_hash),
+            &stellar_address,
+        );
+    }
+
+    /// Resolve a username hash to its primary linked Stellar address.
+    ///
+    /// Returns `NotFound` if the username hash is not registered.
+    /// Returns `NoAddressLinked` if registered but no primary Stellar address has been set.
+    pub fn resolve_stellar(env: Env, username_hash: BytesN<32>) -> Address {
+        // Step 1: verify the commitment is registered at all.
+        if Registration::get_owner(env.clone(), username_hash.clone()).is_none() {
+            panic_with_error!(&env, CoreError::NotFound);
+        }
+
+        // Step 2: return the linked primary Stellar address, or error if absent.
+        env.storage()
+            .persistent()
+            .get::<storage::DataKey, Address>(&storage::DataKey::StellarAddress(username_hash))
+            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NoAddressLinked))
+    }
 }

--- a/gateway-contract/contracts/core_contract/src/storage.rs
+++ b/gateway-contract/contracts/core_contract/src/storage.rs
@@ -8,4 +8,6 @@ pub enum DataKey {
     Resolver(BytesN<32>),
     /// Key for the SMT root in instance storage.
     SmtRoot,
+    /// Key for the primary Stellar address linked to a username hash.
+    StellarAddress(BytesN<32>),
 }

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -47,6 +47,94 @@ fn test_set_memo_and_resolve_flow() {
     assert_eq!(memo, Some(4242u64));
 }
 
+// ── resolve_stellar tests ─────────────────────────────────────────────────────
+
+#[test]
+fn test_resolve_stellar_returns_linked_address() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 10);
+
+    client.register(&owner, &hash);
+    client.add_stellar_address(&owner, &hash, &owner);
+
+    let resolved = client.resolve_stellar(&hash);
+    assert_eq!(resolved, owner);
+}
+
+#[test]
+fn test_resolve_stellar_linked_address_differs_from_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let payment_address = Address::generate(&env);
+    let hash = commitment(&env, 11);
+
+    client.register(&owner, &hash);
+    client.add_stellar_address(&owner, &hash, &payment_address);
+
+    let resolved = client.resolve_stellar(&hash);
+    assert_eq!(resolved, payment_address);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_resolve_stellar_not_found_for_unregistered_hash() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let hash = commitment(&env, 12);
+    client.resolve_stellar(&hash);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_resolve_stellar_no_address_linked_when_not_set() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 13);
+
+    client.register(&owner, &hash);
+    // do NOT call add_stellar_address
+    client.resolve_stellar(&hash);
+}
+
+#[test]
+#[should_panic]
+fn test_add_stellar_address_wrong_owner_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let hash = commitment(&env, 14);
+
+    client.register(&owner, &hash);
+    client.add_stellar_address(&attacker, &hash, &attacker);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_add_stellar_address_not_registered_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let caller = Address::generate(&env);
+    let hash = commitment(&env, 15);
+
+    client.add_stellar_address(&caller, &hash, &caller);
+}
+
 // ── SMT root tests ────────────────────────────────────────────────────────────
 
 #[test]

--- a/gateway-contract/contracts/core_contract/test_snapshots/test/test_get_smt_root_panics_when_not_set.1.json
+++ b/gateway-contract/contracts/core_contract/test_snapshots/test/test_get_smt_root_panics_when_not_set.1.json
@@ -1,6 +1,6 @@
 {
   "generators": {
-    "address": 2,
+    "address": 1,
     "nonce": 0,
     "mux_id": 0
   },


### PR DESCRIPTION
## Summary

- Adds `add_stellar_address(env, caller, username_hash, stellar_address)` — only the registered owner can link a primary Stellar address to their username hash
- Adds `resolve_stellar(env, username_hash) -> Address` — resolves a username hash to its primary Stellar address with two distinct typed errors:
  - `NotFound` (#1): the hash was never registered via `register`
  - `NoAddressLinked` (#3): registered but `add_stellar_address` was never called
- Adds `NoAddressLinked = 3` to `CoreError`
- Adds `StellarAddress(BytesN<32>)` storage key to `DataKey`

**Naming note:** The function is `resolve_stellar` rather than `resolve` because an existing `resolve` function (payment-resolver flow, returns `(Address, Option<u64>)`) already occupies that name with the same `BytesN<32>` parameter type. Rust does not support function overloading. Maintainers can decide whether to rename/remove the old `resolve` in a follow-up.

Closes #58.

## Test plan

- [x] `test_resolve_stellar_returns_linked_address` — happy path, owner links and resolves own address
- [x] `test_resolve_stellar_linked_address_differs_from_owner` — payment address differs from owner
- [x] `test_resolve_stellar_not_found_for_unregistered_hash` — panics with Error(Contract, #1)
- [x] `test_resolve_stellar_no_address_linked_when_not_set` — panics with Error(Contract, #3)
- [x] `test_add_stellar_address_wrong_owner_panics` — non-owner cannot link an address
- [x] `test_add_stellar_address_not_registered_panics` — panics with Error(Contract, #1)
- [x] All 20 tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now link a Stellar address to their registered username.
  * Added ability to resolve a username and retrieve its linked Stellar address.
  * Added error handling for cases where a username lacks a linked address.

* **Tests**
  * Added comprehensive test coverage for address linking and resolution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->