### PR TITLE
feat(contract): Implement chain registry with remove functionality and Cosmos support

### DIFF
--- a/gateway-contract/contracts/core_contract/src/address_manager.rs
+++ b/gateway-contract/contracts/core_contract/src/address_manager.rs
@@ -1,7 +1,7 @@
 use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, BytesN, Env};
 
 use crate::errors::ChainAddressError;
-use crate::events::CHAIN_ADD;
+use crate::events::{CHAIN_ADD, CHAIN_REM};
 use crate::registration::DataKey as CommitmentKey;
 use crate::types::ChainType;
 
@@ -72,6 +72,43 @@ impl AddressManager {
         env.storage().persistent().get(&key)
     }
 
+    /// Remove a chain address for a registered username commitment.
+    ///
+    /// - `caller`        – must be the registered owner of `username_hash`
+    /// - `username_hash` – 32-byte Poseidon commitment of the username
+    /// - `chain`         – target chain to remove
+    ///
+    /// Emits `CHAIN_REM` event with `(username_hash, chain)`.
+    pub fn remove_chain_address(
+        env: Env,
+        caller: Address,
+        username_hash: BytesN<32>,
+        chain: ChainType,
+    ) {
+        // 1. Authenticate the caller.
+        caller.require_auth();
+
+        // 2. Verify the commitment is registered and caller is the owner.
+        let owner_key = CommitmentKey::Commitment(username_hash.clone());
+        let owner: Address = env
+            .storage()
+            .persistent()
+            .get(&owner_key)
+            .unwrap_or_else(|| panic_with_error!(&env, ChainAddressError::NotRegistered));
+
+        if owner != caller {
+            panic_with_error!(&env, ChainAddressError::Unauthorized);
+        }
+
+        // 3. Remove the chain address from storage.
+        let key = ChainAddrKey::ChainAddress(username_hash.clone(), chain.clone());
+        env.storage().persistent().remove(&key);
+
+        // 4. Emit event.
+        #[allow(deprecated)]
+        env.events().publish((CHAIN_REM,), (username_hash, chain));
+    }
+
     // ── Validation helpers ──────────────────────────────────────────────────
 
     fn validate_address(chain: &ChainType, address: &Bytes) -> bool {
@@ -87,6 +124,8 @@ impl AddressManager {
             ChainType::Bitcoin => (25..=62).contains(&len),
             // Solana: base58-encoded public key, typically 32–44 chars.
             ChainType::Solana => (32..=44).contains(&len),
+            // Cosmos: bech32-encoded address with prefix, typically 39–45 chars.
+            ChainType::Cosmos => (39..=45).contains(&len),
         }
     }
 }

--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -70,7 +70,7 @@ impl Contract {
         Registration::get_owner(env, commitment)
     }
 
-    /// Link an external chain address (EVM / Bitcoin / Solana) to a username commitment.
+    /// Link an external chain address (EVM / Bitcoin / Solana / Cosmos) to a username commitment.
     /// Only the registered owner of the commitment may call this.
     pub fn add_chain_address(
         env: Env,
@@ -89,5 +89,16 @@ impl Contract {
         chain: ChainType,
     ) -> Option<Bytes> {
         AddressManager::get_chain_address(env, username_hash, chain)
+    }
+
+    /// Remove a chain address for a username commitment.
+    /// Only the registered owner of the commitment may call this.
+    pub fn remove_chain_address(
+        env: Env,
+        caller: Address,
+        username_hash: BytesN<32>,
+        chain: ChainType,
+    ) {
+        AddressManager::remove_chain_address(env, caller, username_hash, chain);
     }
 }

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -120,6 +120,11 @@ fn solana_address(env: &Env) -> Bytes {
     Bytes::from_slice(env, raw)
 }
 
+fn cosmos_address(env: &Env) -> Bytes {
+    let raw = b"cosmos1syavy2npfyt9tcncdtsdzf7kny9lh777yh8aee";
+    Bytes::from_slice(env, raw)
+}
+
 // ── success cases ─────────────────────────────────────────────────────────────
 
 #[test]
@@ -174,14 +179,51 @@ fn test_add_solana_address_success() {
 }
 
 #[test]
+fn test_add_cosmos_address_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 4);
+    let addr = cosmos_address(&env);
+
+    client.register(&owner, &hash);
+    client.add_chain_address(&owner, &hash, &ChainType::Cosmos, &addr);
+
+    let stored = client.get_chain_address(&hash, &ChainType::Cosmos);
+    assert_eq!(stored, Some(addr));
+}
+
+#[test]
 fn test_get_chain_address_returns_none_when_not_set() {
     let env = Env::default();
     env.mock_all_auths();
     let (_, client) = setup(&env);
 
-    let hash = commitment(&env, 4);
+    let hash = commitment(&env, 5);
     let result = client.get_chain_address(&hash, &ChainType::Evm);
     assert_eq!(result, None);
+}
+
+#[test]
+fn test_remove_chain_address_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 6);
+    let addr = evm_address(&env);
+
+    // Add address
+    client.register(&owner, &hash);
+    client.add_chain_address(&owner, &hash, &ChainType::Evm, &addr);
+    assert_eq!(client.get_chain_address(&hash, &ChainType::Evm), Some(addr));
+
+    // Remove address
+    client.remove_chain_address(&owner, &hash, &ChainType::Evm);
+    assert_eq!(client.get_chain_address(&hash, &ChainType::Evm), None);
 }
 
 // ── auth / ownership failures ─────────────────────────────────────────────────
@@ -194,7 +236,7 @@ fn test_add_chain_address_not_registered_panics() {
     let (_, client) = setup(&env);
 
     let caller = Address::generate(&env);
-    let hash = commitment(&env, 5);
+    let hash = commitment(&env, 7);
     let addr = evm_address(&env);
 
     client.add_chain_address(&caller, &hash, &ChainType::Evm, &addr);
@@ -209,11 +251,28 @@ fn test_add_chain_address_wrong_owner_panics() {
 
     let owner = Address::generate(&env);
     let attacker = Address::generate(&env);
-    let hash = commitment(&env, 6);
+    let hash = commitment(&env, 8);
     let addr = evm_address(&env);
 
     client.register(&owner, &hash);
     client.add_chain_address(&attacker, &hash, &ChainType::Evm, &addr);
+}
+
+#[test]
+#[should_panic]
+fn test_remove_chain_address_wrong_owner_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let hash = commitment(&env, 9);
+    let addr = evm_address(&env);
+
+    client.register(&owner, &hash);
+    client.add_chain_address(&owner, &hash, &ChainType::Evm, &addr);
+    client.remove_chain_address(&attacker, &hash, &ChainType::Evm);
 }
 
 // ── address validation failures ───────────────────────────────────────────────
@@ -226,7 +285,7 @@ fn test_invalid_evm_address_wrong_length_panics() {
     let (_, client) = setup(&env);
 
     let owner = Address::generate(&env);
-    let hash = commitment(&env, 7);
+    let hash = commitment(&env, 10);
 
     client.register(&owner, &hash);
     let bad_addr = Bytes::from_slice(&env, b"0x1234567");
@@ -241,7 +300,7 @@ fn test_invalid_evm_address_no_prefix_panics() {
     let (_, client) = setup(&env);
 
     let owner = Address::generate(&env);
-    let hash = commitment(&env, 8);
+    let hash = commitment(&env, 11);
 
     client.register(&owner, &hash);
     let bad_addr = Bytes::from_slice(&env, b"aAbBcCdDeEfF00112233445566778899aAbBcCdDeE");
@@ -256,9 +315,24 @@ fn test_invalid_solana_address_too_short_panics() {
     let (_, client) = setup(&env);
 
     let owner = Address::generate(&env);
-    let hash = commitment(&env, 9);
+    let hash = commitment(&env, 12);
 
     client.register(&owner, &hash);
     let bad_addr = Bytes::from_slice(&env, b"short1234");
     client.add_chain_address(&owner, &hash, &ChainType::Solana, &bad_addr);
+}
+
+#[test]
+#[should_panic]
+fn test_invalid_cosmos_address_too_short_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 13);
+
+    client.register(&owner, &hash);
+    let bad_addr = Bytes::from_slice(&env, b"cosmos123");
+    client.add_chain_address(&owner, &hash, &ChainType::Cosmos, &bad_addr);
 }

--- a/gateway-contract/contracts/core_contract/src/types.rs
+++ b/gateway-contract/contracts/core_contract/src/types.rs
@@ -19,4 +19,5 @@ pub enum ChainType {
     Evm,
     Bitcoin,
     Solana,
+    Cosmos,
 }


### PR DESCRIPTION
## 📝 Description

Implements multi-chain address storage and removal within the `address_manager.rs` module. Adds support for Cosmos blockchain addresses and implements the missing `remove_chain_address` functionality.

Closes #66

## 🔧 Changes

### Added Cosmos Support ([types.rs](https://github.com/Alien-Protocol/Alien-Gateway/blob/feat/contract-chain-registry/gateway-contract/contracts/core_contract/src/types.rs))
- **`ChainType::Cosmos`** variant added to enum
- Now supports: EVM, Bitcoin, Solana, and Cosmos

### Added Remove Functionality ([address_manager.rs](https://github.com/Alien-Protocol/Alien-Gateway/blob/feat/contract-chain-registry/gateway-contract/contracts/core_contract/src/address_manager.rs))
- **`remove_chain_address()`** function with owner authentication
  - Validates caller is registered owner
  - Removes address from persistent storage
  - Emits `CHAIN_REM` event
- **Updated validation** to support Cosmos addresses (39-45 chars)
- **Added import** for `CHAIN_REM` event

### Exposed Contract Entry Point ([lib.rs](https://github.com/Alien-Protocol/Alien-Gateway/blob/feat/contract-chain-registry/gateway-contract/contracts/core_contract/src/lib.rs))
```rust
pub fn remove_chain_address(
    env: Env,
    caller: Address,
    username_hash: BytesN<32>,
    chain: ChainType,
)
```

**Implementation features:**
- ✅ Authenticates caller via `require_auth()`
- ✅ Verifies commitment is registered
- ✅ Validates caller is owner
- ✅ Removes address from storage
- ✅ Emits `CHAIN_REM` event with (username_hash, chain)

### Added Comprehensive Tests ([test.rs](https://github.com/Alien-Protocol/Alien-Gateway/blob/feat/contract-chain-registry/gateway-contract/contracts/core_contract/src/test.rs))
- **`test_add_cosmos_address_success`** - validates Cosmos address addition
- **`test_remove_chain_address_success`** - validates removal workflow
- **`test_remove_chain_address_wrong_owner_panics`** - validates auth check
- **`test_invalid_cosmos_address_too_short_panics`** - validates Cosmos format
- **Helper function** `cosmos_address()` for test data

## ✅ Acceptance Criteria

All requirements from issue #66 met:
- [x] Chain registry functionality in `address_manager.rs`
- [x] `ChainType` enum includes Cosmos
- [x] Auth check rejects non-owner callers
- [x] `CHAIN_REM` event emitted correctly
- [x] Unit tests for all functionality
- [x] `cargo test` passes (18/18 tests passing)
- [x] `cargo clippy` passes with no warnings

## 🧪 Testing

```bash
cd gateway-contract/contracts/core_contract
cargo test                                    # ✅ 18/18 tests pass
cargo build --release --target wasm32-unknown-unknown  # ✅ Build successful
cargo clippy -- -D warnings                   # ✅ No warnings
```

### New Tests Added
```
✅ test_add_cosmos_address_success
✅ test_remove_chain_address_success
✅ test_remove_chain_address_wrong_owner_panics
✅ test_invalid_cosmos_address_too_short_panics
```

## 🔄 Workflow Example

```rust
// Add Cosmos address
let cosmos_addr = Bytes::from_slice(&env, b"cosmos1syavy2npfyt9tcncdtsdzf7kny9lh777yh8aee");
client.add_chain_address(&owner, &hash, &ChainType::Cosmos, &cosmos_addr);

// Retrieve it
let stored = client.get_chain_address(&hash, &ChainType::Cosmos);
assert_eq!(stored, Some(cosmos_addr));

// Remove it
client.remove_chain_address(&owner, &hash, &ChainType::Cosmos);
assert_eq!(client.get_chain_address(&hash, &ChainType::Cosmos), None);
```

## 📊 Impact

- **Lines changed:** +133, -8
- **Files modified:** 4
- **New dependencies:** None
- **Breaking changes:** None (additive only)

## 🔐 Security

- **Owner authentication**: Both add and remove require caller to be registered owner
- **Storage cleanup**: Remove function properly cleans up persistent storage
- **Event transparency**: CHAIN_REM event logs all removal operations
- **Validation**: Cosmos addresses validated with appropriate length checks (39-45 chars)

## 📌 Notes

- `address_manager.rs` already had add/get functionality, this PR completes it with remove
- Cosmos address validation uses length-based check for bech32 format
- CHAIN_REM event was already defined in events.rs, now properly used
- All tests use unique commitment seeds to avoid collisions
- Compatible with existing EVM, Bitcoin, and Solana address storage

---
**Priority:** MED | **Difficulty:** ☕☕ medium | **Phase:** 2 — Core Primitives

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can remove a chain address mapping for a username.
  * Cosmos chain support added alongside EVM, Bitcoin, and Solana.

* **Tests**
  * Added coverage for Cosmos address add/remove and invalid-address handling; ownership checks for removals.

* **Documentation**
  * Updated supported chains list to include Cosmos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->