### PR TITLE
feat(test): implemented registration integration tests 

### DIFF
--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -26,6 +26,59 @@ fn commitment(env: &Env, seed: u8) -> BytesN<32> {
     BytesN::from_array(env, &[seed; 32])
 }
 
+// ── registration tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_register_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 10);
+
+    client.register(&owner, &hash);
+
+    let stored_owner = client.get_owner(&hash);
+    assert_eq!(stored_owner, Some(owner));
+}
+
+#[test]
+#[should_panic(expected = "Commitment already registered")]
+fn test_register_duplicate_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 11);
+
+    client.register(&owner, &hash);
+    client.register(&owner, &hash);
+}
+
+#[test]
+#[should_panic]
+fn test_register_requires_auth() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 12);
+
+    client.register(&owner, &hash);
+}
+
+#[test]
+fn test_get_owner_returns_none_for_unknown() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let hash = commitment(&env, 13);
+    let stored_owner = client.get_owner(&hash);
+    assert_eq!(stored_owner, None);
+}
+
 fn dummy_proof(env: &Env) -> Bytes {
     Bytes::from_slice(env, &[0u8; 64])
 }


### PR DESCRIPTION
This PR adds comprehensive integration tests for the registration flow in the `core_contract`, addressing requirements related to closes #89.

### Key Changes:
- **Duplicate Registration Guard**: Added a test case `test_register_duplicate_panics` to ensure that attempts to register a previously registered hash are correctly rejected with a panic.
- **Authorization Enforcement**: Added `test_register_requires_auth` to verify that the `register` function enforces proper authorization.
- **Querying Unknown Hashes**: Added `test_get_owner_returns_none_for_unknown` to ensure the system gracefully handles queries for non-existent registrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests covering commitment registration and owner retrieval: successful registration persists the owner.
  * Added a test ensuring duplicate registration triggers the expected error.
  * Added a test verifying registration requires proper authorization.
  * Added a test confirming queries for unregistered commitments report no owner.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->