### PR TITLE
feat(factory): define UsernameDeployed and OwnershipTransferred events

### DIFF
--- a/gateway-contract/contracts/factory_contract/src/events.rs
+++ b/gateway-contract/contracts/factory_contract/src/events.rs
@@ -1,8 +1,10 @@
 use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol};
 
 pub const USERNAME_DEPLOYED: Symbol = symbol_short!("USR_DEP");
+#[allow(dead_code)]
 pub const OWNERSHIP_TRANSFERRED: Symbol = symbol_short!("OWN_TRF");
 
+#[allow(deprecated)]
 pub fn emit_username_deployed(
     env: &Env,
     username_hash: &BytesN<32>,
@@ -15,6 +17,8 @@ pub fn emit_username_deployed(
     );
 }
 
+#[allow(dead_code)]
+#[allow(deprecated)]
 pub fn emit_ownership_transferred(
     env: &Env,
     username_hash: &BytesN<32>,

--- a/gateway-contract/contracts/factory_contract/src/events.rs
+++ b/gateway-contract/contracts/factory_contract/src/events.rs
@@ -1,22 +1,28 @@
-use soroban_sdk::{contractevent, Address, BytesN, Env};
+use soroban_sdk::{symbol_short, Address, BytesN, Env, Symbol};
 
-use crate::types::UsernameRecord;
+pub const USERNAME_DEPLOYED: Symbol = symbol_short!("USR_DEP");
+pub const OWNERSHIP_TRANSFERRED: Symbol = symbol_short!("OWN_TRF");
 
-#[contractevent(topics = ["USERNAME_DEPLOYED"], data_format = "single-value")]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct UsernameDeployedEvent {
-    #[topic]
-    pub username_hash: BytesN<32>,
-    #[topic]
-    pub owner: Address,
-    pub record: UsernameRecord,
+pub fn emit_username_deployed(
+    env: &Env,
+    username_hash: &BytesN<32>,
+    owner: &Address,
+    registered_at: u64,
+) {
+    env.events().publish(
+        (USERNAME_DEPLOYED,),
+        (username_hash.clone(), owner.clone(), registered_at),
+    );
 }
 
-pub fn emit_username_deployed(env: &Env, record: &UsernameRecord) {
-    UsernameDeployedEvent {
-        username_hash: record.username_hash.clone(),
-        owner: record.owner.clone(),
-        record: record.clone(),
-    }
-    .publish(env);
+pub fn emit_ownership_transferred(
+    env: &Env,
+    username_hash: &BytesN<32>,
+    old_owner: &Address,
+    new_owner: &Address,
+) {
+    env.events().publish(
+        (OWNERSHIP_TRANSFERRED,),
+        (username_hash.clone(), old_owner.clone(), new_owner.clone()),
+    );
 }

--- a/gateway-contract/contracts/factory_contract/src/lib.rs
+++ b/gateway-contract/contracts/factory_contract/src/lib.rs
@@ -52,7 +52,12 @@ impl FactoryContract {
         };
 
         set_username_record(&env, &record);
-        emit_username_deployed(&env, &record.username_hash, &record.owner, record.registered_at);
+        emit_username_deployed(
+            &env,
+            &record.username_hash,
+            &record.owner,
+            record.registered_at,
+        );
     }
 
     pub fn get_username_record(env: Env, username_hash: BytesN<32>) -> Option<UsernameRecord> {

--- a/gateway-contract/contracts/factory_contract/src/lib.rs
+++ b/gateway-contract/contracts/factory_contract/src/lib.rs
@@ -52,7 +52,7 @@ impl FactoryContract {
         };
 
         set_username_record(&env, &record);
-        emit_username_deployed(&env, &record);
+        emit_username_deployed(&env, &record.username_hash, &record.owner, record.registered_at);
     }
 
     pub fn get_username_record(env: Env, username_hash: BytesN<32>) -> Option<UsernameRecord> {

--- a/gateway-contract/contracts/factory_contract/src/test.rs
+++ b/gateway-contract/contracts/factory_contract/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
-use soroban_sdk::{contract, contractimpl, IntoVal, Symbol, TryFromVal, Val, Vec};
+use soroban_sdk::{contract, contractimpl, symbol_short, IntoVal, Symbol, TryFromVal, Val, Vec};
 use soroban_sdk::{Address, BytesN, Env};
 
 use crate::errors::FactoryError;
@@ -58,17 +58,16 @@ fn deploy_username_stores_record_and_emits_event() {
 
     let (event_contract, topics, data) = events.get(0).unwrap();
     assert_eq!(event_contract, factory_id);
-    assert_eq!(topics.len(), 3);
+    assert_eq!(topics.len(), 1);
 
     let event_name = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
-    let event_hash = BytesN::<32>::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
-    let event_owner = Address::try_from_val(&env, &topics.get(2).unwrap()).unwrap();
-    let event_record = crate::types::UsernameRecord::try_from_val(&env, &data).unwrap();
+    let (event_hash, event_owner, event_registered_at) =
+        <(BytesN<32>, Address, u64)>::try_from_val(&env, &data).unwrap();
 
-    assert_eq!(event_name, Symbol::new(&env, "USERNAME_DEPLOYED"));
+    assert_eq!(event_name, symbol_short!("USR_DEP"));
     assert_eq!(event_hash, hash);
     assert_eq!(event_owner, owner);
-    assert_eq!(event_record, record);
+    assert_eq!(event_registered_at, record.registered_at);
 }
 
 #[test]

--- a/gateway-contract/contracts/factory_contract/src/test.rs
+++ b/gateway-contract/contracts/factory_contract/src/test.rs
@@ -1,10 +1,11 @@
 #![cfg(test)]
 
 use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
-use soroban_sdk::{contract, contractimpl, symbol_short, IntoVal, Symbol, TryFromVal, Val, Vec};
+use soroban_sdk::{contract, contractimpl, IntoVal, Symbol, TryFromVal, Val, Vec};
 use soroban_sdk::{Address, BytesN, Env};
 
 use crate::errors::FactoryError;
+use crate::events::USERNAME_DEPLOYED;
 use crate::{FactoryContract, FactoryContractClient};
 
 #[contract]
@@ -64,7 +65,7 @@ fn deploy_username_stores_record_and_emits_event() {
     let (event_hash, event_owner, event_registered_at) =
         <(BytesN<32>, Address, u64)>::try_from_val(&env, &data).unwrap();
 
-    assert_eq!(event_name, symbol_short!("USR_DEP"));
+    assert_eq!(event_name, USERNAME_DEPLOYED);
     assert_eq!(event_hash, hash);
     assert_eq!(event_owner, owner);
     assert_eq!(event_registered_at, record.registered_at);


### PR DESCRIPTION
Implements factory event symbols and spec-compliant emit helpers for username deployment and ownership transfer.

Closes #104

---

### Checklist

- [x] Defined `USERNAME_DEPLOYED` → `symbol_short!("USR_DEP")`
- [x] Defined `OWNERSHIP_TRANSFERRED` → `symbol_short!("OWN_TRF")`
- [x] Symbols ≤ 9 characters
- [x] Payloads match spec:
  - `USERNAME_DEPLOYED` → `(username_hash, owner, registered_at)`
  - `OWNERSHIP_TRANSFERRED` → `(username_hash, old_owner, new_owner)`
- [x] Imported in `lib.rs`
- [x] Used manual `env.events().publish` (required for const Symbols)
- [x] `cargo build` passes

---

###  Notes

- `OWNERSHIP_TRANSFERRED` emitter is defined but not yet used
- Deprecation warnings for `publish` are expected due to current Soroban constraints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit ownership-transfer events so ownership changes for registered usernames are published and trackable.
  * Introduced compact, named event topics for username deployment and ownership transfers.

* **Chores**
  * Switched username deployment to a single-topic, compact payload event format for simpler consumption.

* **Tests**
  * Updated tests to validate the new single-topic event and its compact payload contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->