### PR TITLE
test(core-contract): add contracttype roundtrip storage tests

### DIFF
--- a/gateway-contract/Cargo.lock
+++ b/gateway-contract/Cargo.lock
@@ -269,6 +269,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "core_contract"
 version = "0.0.0"
 dependencies = [
+ "escrow_contract",
  "soroban-sdk",
 ]
 

--- a/gateway-contract/contracts/core_contract/Cargo.toml
+++ b/gateway-contract/contracts/core_contract/Cargo.toml
@@ -13,3 +13,4 @@ soroban-sdk = { workspace = true }
 
 [dev-dependencies]
 soroban-sdk = { workspace = true, features = ["testutils"] }
+escrow_contract = { path = "../escrow_contract" }

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -113,7 +113,9 @@ fn test_scheduled_payment_roundtrip() {
 
     let stored = env.as_contract(&contract_id, || {
         env.storage().persistent().set(&key, &payment);
-        env.storage().persistent().get::<_, EscrowScheduledPayment>(&key)
+        env.storage()
+            .persistent()
+            .get::<_, EscrowScheduledPayment>(&key)
     });
     assert_eq!(stored, Some(payment));
 }

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -1,10 +1,13 @@
 #![cfg(test)]
 
 use crate::smt_root::SmtRoot;
-use crate::types::{ChainType, PublicSignals};
+use crate::types::{AddressMetadata, ChainType, PublicSignals};
 use crate::{Contract, ContractClient};
+use escrow_contract::types::{
+    AutoPay, ScheduledPayment as EscrowScheduledPayment, VaultConfig, VaultState,
+};
 use soroban_sdk::testutils::{Address as _, Events};
-use soroban_sdk::{Address, Bytes, BytesN, Env};
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, Symbol};
 
 fn setup(env: &Env) -> (Address, ContractClient<'_>) {
     let contract_id = env.register(Contract, ());
@@ -28,6 +31,112 @@ fn commitment(env: &Env, seed: u8) -> BytesN<32> {
 
 fn dummy_proof(env: &Env) -> Bytes {
     Bytes::from_slice(env, &[0u8; 64])
+}
+
+#[contracttype]
+#[derive(Clone)]
+enum RoundtripKey {
+    AddressMetadata,
+    VaultConfig,
+    VaultState,
+    ScheduledPayment,
+    AutoPay,
+}
+
+// ── contracttype roundtrip tests ─────────────────────────────────────────────
+
+#[test]
+fn test_address_metadata_roundtrip() {
+    let env = Env::default();
+    let (contract_id, _) = setup(&env);
+    let key = RoundtripKey::AddressMetadata;
+    let label = Symbol::new(&env, "primary");
+    let metadata = AddressMetadata {
+        label: label.clone(),
+    };
+
+    let stored = env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&key, &metadata);
+        env.storage().persistent().get::<_, AddressMetadata>(&key)
+    });
+    assert_eq!(stored.map(|item| item.label), Some(label));
+}
+
+#[test]
+fn test_vault_config_roundtrip() {
+    let env = Env::default();
+    let (contract_id, _) = setup(&env);
+    let key = RoundtripKey::VaultConfig;
+    let config = VaultConfig {
+        owner: Address::generate(&env),
+        token: Address::generate(&env),
+        created_at: 1_729_000_001,
+    };
+
+    let stored = env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&key, &config);
+        env.storage().persistent().get::<_, VaultConfig>(&key)
+    });
+    assert_eq!(stored, Some(config));
+}
+
+#[test]
+fn test_vault_state_roundtrip() {
+    let env = Env::default();
+    let (contract_id, _) = setup(&env);
+    let key = RoundtripKey::VaultState;
+    let state = VaultState {
+        balance: 5_000,
+        is_active: true,
+    };
+
+    let stored = env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&key, &state);
+        env.storage().persistent().get::<_, VaultState>(&key)
+    });
+    assert_eq!(stored, Some(state));
+}
+
+#[test]
+fn test_scheduled_payment_roundtrip() {
+    let env = Env::default();
+    let (contract_id, _) = setup(&env);
+    let key = RoundtripKey::ScheduledPayment;
+    let payment = EscrowScheduledPayment {
+        from: BytesN::from_array(&env, &[7u8; 32]),
+        to: BytesN::from_array(&env, &[8u8; 32]),
+        token: Address::generate(&env),
+        amount: 900,
+        release_at: 3_600,
+        executed: false,
+    };
+
+    let stored = env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&key, &payment);
+        env.storage().persistent().get::<_, EscrowScheduledPayment>(&key)
+    });
+    assert_eq!(stored, Some(payment));
+}
+
+#[test]
+fn test_auto_pay_roundtrip() {
+    let env = Env::default();
+    let (contract_id, _) = setup(&env);
+    let key = RoundtripKey::AutoPay;
+    let rule = AutoPay {
+        from: BytesN::from_array(&env, &[9u8; 32]),
+        to: BytesN::from_array(&env, &[10u8; 32]),
+        token: Address::generate(&env),
+        amount: 250,
+        interval: 86_400,
+        last_paid: 0,
+    };
+
+    let stored = env.as_contract(&contract_id, || {
+        env.storage().persistent().set(&key, &rule);
+        env.storage().persistent().get::<_, AutoPay>(&key)
+    });
+    assert_eq!(stored, Some(rule));
 }
 
 // ── resolver / memo tests ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

This PR adds roundtrip serialization/deserialization unit tests for `#[contracttype]` structs used in the Soroban environment to catch encoding regressions early.

## What Changed

- Added 5 roundtrip tests in `gateway-contract/contracts/core_contract/src/test.rs`:
  - `test_address_metadata_roundtrip`
  - `test_vault_config_roundtrip`
  - `test_vault_state_roundtrip`
  - `test_scheduled_payment_roundtrip`
  - `test_auto_pay_roundtrip`
- Added a dedicated test storage key enum for isolated roundtrip fixtures.
- Added `escrow_contract` as a dev-dependency in `core_contract` tests because `VaultConfig`, `VaultState`, `ScheduledPayment`, and `AutoPay` are defined there.

## Why

Issue #90 requests coverage ensuring contract types serialize and deserialize correctly in Soroban storage, reducing risk of subtle encoding bugs surfacing in integration flows.

## How to Verify

From the repository root:

```bash
cd gateway-contract
cargo test -p core_contract
cargo test
```

Expected result:
- All `core_contract` tests pass, including the 5 new roundtrip tests.
- Workspace test suite is green.

## Footer

Closes https://github.com/Alien-Protocol/Alien-Gateway/issues/90


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added development dependency for contract testing infrastructure.

* **Tests**
  * Expanded test coverage with new roundtrip persistence tests for contract data types, ensuring proper storage and retrieval functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->