### PR TITLE
feat: Implement close_auction function (Closes #98)

### DIFF
--- a/gateway-contract/contracts/auction_contract/src/errors.rs
+++ b/gateway-contract/contracts/auction_contract/src/errors.rs
@@ -12,4 +12,5 @@ pub enum AuctionError {
     InvalidState = 6,
     BidTooLow = 7,
     AuctionNotOpen = 8,
+    AuctionNotClosed = 9,
 }

--- a/gateway-contract/contracts/auction_contract/src/events.rs
+++ b/gateway-contract/contracts/auction_contract/src/events.rs
@@ -39,11 +39,18 @@ pub struct AuctionClosedEvent {
 pub struct UsernameClaimedEvent {
     #[topic]
     pub username_hash: BytesN<32>,
-    pub owner: Address,
+    pub claimer: Address,
 }
 
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuctionClosedEvent {
+    #[topic]
+    pub username_hash: BytesN<32>,
+    pub winner: Option<Address>,
+    pub winning_bid: u128,
+}
+
 pub struct BidRefundedEvent {
     #[topic]
     pub username_hash: BytesN<32>,
@@ -72,21 +79,21 @@ pub fn emit_bid_placed(env: &Env, username_hash: &BytesN<32>, bidder: &Address, 
 pub fn emit_auction_closed(
     env: &Env,
     username_hash: &BytesN<32>,
-    winner: &Address,
-    winning_bid: i128,
+    winner: Option<Address>,
+    winning_bid: u128,
 ) {
     AuctionClosedEvent {
         username_hash: username_hash.clone(),
-        winner: winner.clone(),
+        winner,
         winning_bid,
     }
     .publish(env);
 }
 
-pub fn emit_username_claimed(env: &Env, username_hash: &BytesN<32>, owner: &Address) {
+pub fn emit_username_claimed(env: &Env, username_hash: &BytesN<32>, claimer: &Address) {
     UsernameClaimedEvent {
         username_hash: username_hash.clone(),
-        owner: owner.clone(),
+        claimer: claimer.clone(),
     }
     .publish(env);
 }

--- a/gateway-contract/contracts/auction_contract/src/events.rs
+++ b/gateway-contract/contracts/auction_contract/src/events.rs
@@ -30,8 +30,8 @@ pub struct BidPlacedEvent {
 pub struct AuctionClosedEvent {
     #[topic]
     pub username_hash: BytesN<32>,
-    pub winner: Address,
-    pub winning_bid: i128,
+    pub winner: Option<Address>,
+    pub winning_bid: u128,
 }
 
 #[contractevent]
@@ -44,13 +44,6 @@ pub struct UsernameClaimedEvent {
 
 #[contractevent]
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AuctionClosedEvent {
-    #[topic]
-    pub username_hash: BytesN<32>,
-    pub winner: Option<Address>,
-    pub winning_bid: u128,
-}
-
 pub struct BidRefundedEvent {
     #[topic]
     pub username_hash: BytesN<32>,

--- a/gateway-contract/contracts/auction_contract/src/lib.rs
+++ b/gateway-contract/contracts/auction_contract/src/lib.rs
@@ -28,6 +28,39 @@ pub struct AuctionContract;
 
 #[contractimpl]
 impl AuctionContract {
+    pub fn close_auction(
+        env: Env,
+        username_hash: BytesN<32>,
+    ) -> Result<(), crate::errors::AuctionError> {
+        let status = storage::get_status(&env);
+
+        // Reject if status is not Open
+        if status != types::AuctionStatus::Open {
+            return Err(crate::errors::AuctionError::AuctionNotOpen);
+        }
+
+        // Get current ledger timestamp and end time
+        let current_time = env.ledger().timestamp();
+        let end_time = storage::get_end_time(&env);
+
+        // Reject if timestamp < end_time
+        if current_time < end_time {
+            return Err(crate::errors::AuctionError::AuctionNotClosed);
+        }
+
+        // Set status to Closed
+        storage::set_status(&env, types::AuctionStatus::Closed);
+
+        // Get winner and winning bid
+        let winner = storage::get_highest_bidder(&env);
+        let winning_bid = storage::get_highest_bid(&env);
+
+        // Emit AUCTION_CLOSED event with winner and winning bid
+        events::emit_auction_closed(&env, &username_hash, winner.clone(), winning_bid);
+
+        Ok(())
+    }
+
     pub fn claim_username(
         env: Env,
         username_hash: BytesN<32>,

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::types::{AuctionStatus, DataKey};
-use soroban_sdk::{Address, Env};
+use soroban_sdk::{u128, Address, Env};
 
 pub fn get_status(env: &Env) -> AuctionStatus {
     env.storage()
@@ -30,4 +30,23 @@ pub fn set_factory_contract(env: &Env, factory: &Address) {
     env.storage()
         .instance()
         .set(&DataKey::FactoryContract, factory);
+}
+
+pub fn get_end_time(env: &Env) -> u64 {
+    env.storage().instance().get(&DataKey::EndTime).unwrap_or(0)
+}
+
+pub fn set_end_time(env: &Env, end_time: u64) {
+    env.storage().instance().set(&DataKey::EndTime, &end_time);
+}
+
+pub fn get_highest_bid(env: &Env) -> u128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::HighestBid)
+        .unwrap_or(0)
+}
+
+pub fn set_highest_bid(env: &Env, bid: u128) {
+    env.storage().instance().set(&DataKey::HighestBid, &bid);
 }

--- a/gateway-contract/contracts/auction_contract/src/storage.rs
+++ b/gateway-contract/contracts/auction_contract/src/storage.rs
@@ -1,5 +1,5 @@
 use crate::types::{AuctionStatus, DataKey};
-use soroban_sdk::{u128, Address, Env};
+use soroban_sdk::{Address, Env};
 
 pub fn get_status(env: &Env) -> AuctionStatus {
     env.storage()

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -124,3 +124,145 @@ fn test_no_factory_contract() {
     });
     client.claim_username(&username_hash, &claimer);
 }
+
+// Tests for close_auction
+
+#[test]
+fn test_close_auction_success() {
+    let env = Env::default();
+
+    let contract_id = env.register_contract(None, AuctionContract);
+    let client = AuctionContractClient::new(&env, &contract_id);
+
+    let username_hash = BytesN::from_array(&env, &[1; 32]);
+    let bidder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        // Set up auction state
+        storage::set_status(&env, types::AuctionStatus::Open);
+        storage::set_end_time(&env, 1000);
+        storage::set_highest_bidder(&env, &bidder);
+        storage::set_highest_bid(&env, 100);
+    });
+
+    // Advance ledger to make current_time > end_time
+    env.ledger().with_mut(|l| {
+        l.timestamp = 2000;
+    });
+
+    let result = client.close_auction(&username_hash);
+    assert!(result.is_ok());
+
+    // Verify status changed to Closed
+    env.as_contract(&contract_id, || {
+        let status = storage::get_status(&env);
+        assert_eq!(status, types::AuctionStatus::Closed);
+    });
+}
+
+#[test]
+fn test_close_auction_zero_bid() {
+    let env = Env::default();
+
+    let contract_id = env.register_contract(None, AuctionContract);
+    let client = AuctionContractClient::new(&env, &contract_id);
+
+    let username_hash = BytesN::from_array(&env, &[2; 32]);
+
+    env.as_contract(&contract_id, || {
+        // Set up auction state with no bidder (zero-bid auction)
+        storage::set_status(&env, types::AuctionStatus::Open);
+        storage::set_end_time(&env, 1000);
+        storage::set_highest_bid(&env, 0);
+    });
+
+    // Advance ledger to make current_time > end_time
+    env.ledger().with_mut(|l| {
+        l.timestamp = 2000;
+    });
+
+    let result = client.close_auction(&username_hash);
+    assert!(result.is_ok());
+
+    // Verify status changed to Closed
+    env.as_contract(&contract_id, || {
+        let status = storage::get_status(&env);
+        assert_eq!(status, types::AuctionStatus::Closed);
+    });
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #9)")]
+fn test_close_auction_not_expired() {
+    let env = Env::default();
+
+    let contract_id = env.register_contract(None, AuctionContract);
+    let client = AuctionContractClient::new(&env, &contract_id);
+
+    let username_hash = BytesN::from_array(&env, &[3; 32]);
+    let bidder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_status(&env, types::AuctionStatus::Open);
+        storage::set_end_time(&env, 5000); // End time is in the future
+        storage::set_highest_bidder(&env, &bidder);
+        storage::set_highest_bid(&env, 100);
+    });
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 2000; // Current time is before end time
+    });
+
+    client.close_auction(&username_hash);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #8)")]
+fn test_close_auction_not_open() {
+    let env = Env::default();
+
+    let contract_id = env.register_contract(None, AuctionContract);
+    let client = AuctionContractClient::new(&env, &contract_id);
+
+    let username_hash = BytesN::from_array(&env, &[4; 32]);
+
+    env.as_contract(&contract_id, || {
+        // Auction is already closed
+        storage::set_status(&env, types::AuctionStatus::Closed);
+        storage::set_end_time(&env, 1000);
+    });
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 2000;
+    });
+
+    client.close_auction(&username_hash);
+}
+
+#[test]
+fn test_close_auction_emits_event() {
+    let env = Env::default();
+
+    let contract_id = env.register_contract(None, AuctionContract);
+    let client = AuctionContractClient::new(&env, &contract_id);
+
+    let username_hash = BytesN::from_array(&env, &[5; 32]);
+    let bidder = Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        storage::set_status(&env, types::AuctionStatus::Open);
+        storage::set_end_time(&env, 1000);
+        storage::set_highest_bidder(&env, &bidder);
+        storage::set_highest_bid(&env, 500);
+    });
+
+    env.ledger().with_mut(|l| {
+        l.timestamp = 2000;
+    });
+
+    client.close_auction(&username_hash);
+
+    // Verify event was emitted
+    let events = env.events().all();
+    assert!(events.len() > 0);
+}

--- a/gateway-contract/contracts/auction_contract/src/test.rs
+++ b/gateway-contract/contracts/auction_contract/src/test.rs
@@ -2,9 +2,8 @@
 
 use super::*;
 use soroban_sdk::{
-    symbol_short,
-    testutils::{Address as _, Events},
-    Address, BytesN, Env, IntoVal,
+    testutils::{Address as _, Events, Ledger},
+    Address, BytesN, Env,
 };
 
 // Dummy factory contract
@@ -12,10 +11,7 @@ use soroban_sdk::{
 pub struct DummyFactory;
 #[contractimpl]
 impl DummyFactory {
-    pub fn deploy_username(env: Env, username_hash: BytesN<32>, claimer: Address) {
-        env.events()
-            .publish((symbol_short!("deploy"), username_hash), claimer);
-    }
+    pub fn deploy_username(_env: Env, _username_hash: BytesN<32>, _claimer: Address) {}
 }
 
 #[test]
@@ -23,10 +19,10 @@ fn test_claim_username_success() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
-    let factory_id = env.register_contract(None, DummyFactory);
+    let factory_id = env.register(DummyFactory, ());
     let claimer = Address::generate(&env);
     let username_hash = BytesN::from_array(&env, &[0; 32]);
 
@@ -48,10 +44,10 @@ fn test_not_winner() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
-    let factory_id = env.register_contract(None, DummyFactory);
+    let factory_id = env.register(DummyFactory, ());
     let winner = Address::generate(&env);
     let not_winner = Address::generate(&env);
     let username_hash = BytesN::from_array(&env, &[0; 32]);
@@ -70,10 +66,10 @@ fn test_already_claimed() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
-    let factory_id = env.register_contract(None, DummyFactory);
+    let factory_id = env.register(DummyFactory, ());
     let claimer = Address::generate(&env);
     let username_hash = BytesN::from_array(&env, &[0; 32]);
 
@@ -91,10 +87,10 @@ fn test_not_closed() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
-    let factory_id = env.register_contract(None, DummyFactory);
+    let factory_id = env.register(DummyFactory, ());
     let claimer = Address::generate(&env);
     let username_hash = BytesN::from_array(&env, &[0; 32]);
 
@@ -112,7 +108,7 @@ fn test_no_factory_contract() {
     let env = Env::default();
     env.mock_all_auths();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
     let claimer = Address::generate(&env);
@@ -131,7 +127,7 @@ fn test_no_factory_contract() {
 fn test_close_auction_success() {
     let env = Env::default();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
     let username_hash = BytesN::from_array(&env, &[1; 32]);
@@ -150,8 +146,7 @@ fn test_close_auction_success() {
         l.timestamp = 2000;
     });
 
-    let result = client.close_auction(&username_hash);
-    assert!(result.is_ok());
+    client.close_auction(&username_hash);
 
     // Verify status changed to Closed
     env.as_contract(&contract_id, || {
@@ -164,7 +159,7 @@ fn test_close_auction_success() {
 fn test_close_auction_zero_bid() {
     let env = Env::default();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
     let username_hash = BytesN::from_array(&env, &[2; 32]);
@@ -181,8 +176,7 @@ fn test_close_auction_zero_bid() {
         l.timestamp = 2000;
     });
 
-    let result = client.close_auction(&username_hash);
-    assert!(result.is_ok());
+    client.close_auction(&username_hash);
 
     // Verify status changed to Closed
     env.as_contract(&contract_id, || {
@@ -196,7 +190,7 @@ fn test_close_auction_zero_bid() {
 fn test_close_auction_not_expired() {
     let env = Env::default();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
     let username_hash = BytesN::from_array(&env, &[3; 32]);
@@ -221,7 +215,7 @@ fn test_close_auction_not_expired() {
 fn test_close_auction_not_open() {
     let env = Env::default();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
     let username_hash = BytesN::from_array(&env, &[4; 32]);
@@ -243,7 +237,7 @@ fn test_close_auction_not_open() {
 fn test_close_auction_emits_event() {
     let env = Env::default();
 
-    let contract_id = env.register_contract(None, AuctionContract);
+    let contract_id = env.register(AuctionContract, ());
     let client = AuctionContractClient::new(&env, &contract_id);
 
     let username_hash = BytesN::from_array(&env, &[5; 32]);

--- a/gateway-contract/contracts/auction_contract/src/types.rs
+++ b/gateway-contract/contracts/auction_contract/src/types.rs
@@ -14,4 +14,6 @@ pub enum DataKey {
     Status,
     HighestBidder,
     FactoryContract,
+    EndTime,
+    HighestBid,
 }


### PR DESCRIPTION
Close #98

## Issue #98: Implement close_auction function

### Overview
Implement the `close_auction` function to mark an auction as closed after the timer expires. 
Flow: "Timer ends — auction closes."

### Implementation Details

#### Function Signature
```rust
pub fn close_auction(env: Env, username_hash: BytesN<32>) -> Result<(), crate::errors::Error>

Closes #98 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `close_auction` method to finalize auctions when the end time is reached, updating auction status and emitting closure events with winner and winning bid details.

* **Improvements**
  * Updated event field naming and types for clearer auction state reporting: `owner` → `claimer`, optional winner handling, standardized bid amount representation.

* **Error Handling**
  * Added `AuctionNotClosed` error state for validation when attempting to close auctions that haven't reached their end time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->