### PR TITLE
feat: implement get_username_owner in factory contract 

### DIFF
--- a/gateway-contract/contracts/factory_contract/src/lib.rs
+++ b/gateway-contract/contracts/factory_contract/src/lib.rs
@@ -59,6 +59,14 @@ impl FactoryContract {
         get_username_record(&env, &username_hash)
     }
 
+    /// Returns the owner of a deployed username, or `None` if not registered.
+    ///
+    /// **Complexity**: O(1) — single persistent storage lookup.
+    /// **Auth**: none — read-only, safe for public polling.
+    pub fn get_username_owner(env: Env, username_hash: BytesN<32>) -> Option<Address> {
+        get_username_record(&env, &username_hash).map(|r| r.owner)
+    }
+
     pub fn get_auction_contract(env: Env) -> Option<Address> {
         get_auction_contract(&env)
     }

--- a/gateway-contract/contracts/factory_contract/src/test.rs
+++ b/gateway-contract/contracts/factory_contract/src/test.rs
@@ -138,3 +138,34 @@ fn non_registered_auction_auth_is_rejected() {
     assert!(result.is_err());
     assert_ne!(wrong_caller, auction_contract);
 }
+
+#[test]
+fn get_username_owner_returns_owner_after_deploy() {
+    let env = Env::default();
+    let (factory_id, factory, auction_contract, _) = setup_factory(&env);
+    let owner = Address::generate(&env);
+    let hash = username_hash(&env);
+    let deploy_args: Vec<Val> = (hash.clone(), owner.clone()).into_val(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "deploy_username",
+            args: deploy_args,
+            sub_invokes: &[],
+        },
+    }]);
+    factory.deploy_username(&hash, &owner);
+
+    assert_eq!(factory.get_username_owner(&hash), Some(owner));
+}
+
+#[test]
+fn get_username_owner_returns_none_for_unregistered_hash() {
+    let env = Env::default();
+    let (_, factory, _, _) = setup_factory(&env);
+    let unknown_hash = BytesN::from_array(&env, &[0xFF; 32]);
+
+    assert_eq!(factory.get_username_owner(&unknown_hash), None);
+}


### PR DESCRIPTION
Closes #107
This PR implements the get_username_owner read-only getter in the factory contract to resolve issue #107. It achieves O(1) time and space complexity by cleanly projecting the owner field from the pre-existing storage record without requiring authentication. Additionally, unit tests were added to confirm the correct owner is returned after deployment and that unregistered hashes safely return None without panicking.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a query method to retrieve the owner of registered usernames.

* **Tests**
  * Added unit tests validating username owner lookup for both registered and unregistered usernames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->