### PR TITLE
feat: implement privacy mode toggle in core_contract (#109)

### DIFF
--- a/gateway-contract/contracts/core_contract/src/address_manager.rs
+++ b/gateway-contract/contracts/core_contract/src/address_manager.rs
@@ -1,14 +1,30 @@
-use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, BytesN, Env};
+use soroban_sdk::{
+    contracterror, contractevent, contracttype, panic_with_error, Address, Bytes, BytesN, Env,
+};
 
 use crate::errors::ChainAddressError;
 use crate::events::{CHAIN_ADD, CHAIN_REM};
-use crate::registration::DataKey as CommitmentKey;
-use crate::types::ChainType;
+use crate::registration::{DataKey as CommitmentKey, Registration};
+use crate::types::{ChainType, PrivacyMode};
 
 #[contracttype]
 #[derive(Clone)]
 pub enum ChainAddrKey {
     ChainAddress(BytesN<32>, ChainType),
+    Privacy(BytesN<32>),
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PrivSet {
+    pub username_hash: BytesN<32>,
+    pub mode: u32,
+}
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AddressManagerError {
+    UsernameNotRegistered = 1,
 }
 
 pub struct AddressManager;
@@ -79,6 +95,34 @@ impl AddressManager {
 
         #[allow(deprecated)]
         env.events().publish((CHAIN_REM,), (username_hash, chain));
+    }
+
+    pub fn set_privacy_mode(env: Env, username_hash: BytesN<32>, mode: PrivacyMode) {
+        let owner = Registration::get_owner(env.clone(), username_hash.clone())
+            .unwrap_or_else(|| panic_with_error!(&env, AddressManagerError::UsernameNotRegistered));
+
+        owner.require_auth();
+
+        let key = ChainAddrKey::Privacy(username_hash.clone());
+        env.storage().persistent().set(&key, &mode);
+
+        let mode_val: u32 = match mode {
+            PrivacyMode::Normal => 0,
+            PrivacyMode::Private => 1,
+        };
+        PrivSet {
+            username_hash,
+            mode: mode_val,
+        }
+        .publish(&env);
+    }
+
+    pub fn get_privacy_mode(env: Env, username_hash: BytesN<32>) -> PrivacyMode {
+        let key = ChainAddrKey::Privacy(username_hash);
+        env.storage()
+            .persistent()
+            .get(&key)
+            .unwrap_or(PrivacyMode::Normal)
     }
 
     fn validate_address(chain: &ChainType, address: &Bytes) -> bool {

--- a/gateway-contract/contracts/core_contract/src/events.rs
+++ b/gateway-contract/contracts/core_contract/src/events.rs
@@ -10,6 +10,7 @@ pub const MASTER_SET: Symbol = symbol_short!("MSTR_SET");
 pub const ADDR_ADDED: Symbol = symbol_short!("ADDR_ADD");
 pub const CHAIN_ADD: Symbol = symbol_short!("CHAIN_ADD");
 pub const CHAIN_REM: Symbol = symbol_short!("CHAIN_REM");
+pub const PRIV_SET: Symbol = symbol_short!("PRIV_SET");
 pub const VAULT_CREATE: Symbol = symbol_short!("VAULT_CRT");
 pub const DEPOSIT: Symbol = symbol_short!("DEPOSIT");
 pub const WITHDRAW: Symbol = symbol_short!("WITHDRAW");

--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -17,7 +17,7 @@ use errors::CoreError;
 use events::{REGISTER_EVENT, TRANSFER_EVENT};
 use registration::Registration;
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Bytes, BytesN, Env};
-use types::{ChainType, PublicSignals, ResolveData};
+use types::{ChainType, PrivacyMode, PublicSignals, ResolveData};
 
 #[contract]
 pub struct Contract;
@@ -79,13 +79,28 @@ impl Contract {
             .set(&storage::DataKey::Resolver(commitment), &data);
     }
 
+    pub fn set_privacy_mode(env: Env, username_hash: BytesN<32>, mode: PrivacyMode) {
+        AddressManager::set_privacy_mode(env, username_hash, mode);
+    }
+
+    pub fn get_privacy_mode(env: Env, username_hash: BytesN<32>) -> PrivacyMode {
+        AddressManager::get_privacy_mode(env, username_hash)
+    }
+
     pub fn resolve(env: Env, commitment: BytesN<32>) -> (Address, Option<u64>) {
         match env
             .storage()
             .persistent()
-            .get::<storage::DataKey, ResolveData>(&storage::DataKey::Resolver(commitment))
+            .get::<storage::DataKey, ResolveData>(&storage::DataKey::Resolver(commitment.clone()))
         {
-            Some(data) => (data.wallet, data.memo),
+            Some(data) => {
+                if AddressManager::get_privacy_mode(env.clone(), commitment) == PrivacyMode::Private
+                {
+                    (env.current_contract_address(), data.memo)
+                } else {
+                    (data.wallet, data.memo)
+                }
+            }
             None => panic_with_error!(&env, CoreError::NotFound),
         }
     }

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::smt_root::SmtRoot;
-use crate::types::{AddressMetadata, ChainType, PublicSignals};
+use crate::types::{AddressMetadata, ChainType, PrivacyMode, PublicSignals};
 use crate::{Contract, ContractClient};
 use escrow_contract::types::{
     AutoPay, ScheduledPayment as EscrowScheduledPayment, VaultConfig, VaultState,
@@ -234,6 +234,62 @@ fn test_set_memo_and_resolve_flow() {
     let (resolved_wallet, memo) = client.resolve(&hash);
     assert_eq!(resolved_wallet, caller);
     assert_eq!(memo, Some(4242u64));
+}
+
+#[test]
+fn test_privacy_mode_resolve_shields_registered_wallet() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client, root) = setup_with_root(&env);
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 40);
+    let new_root = BytesN::from_array(&env, &[41u8; 32]);
+
+    client.register(&owner, &hash);
+    client.register_resolver(
+        &owner,
+        &hash,
+        &dummy_proof(&env),
+        &PublicSignals {
+            old_root: root,
+            new_root,
+        },
+    );
+
+    assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Normal);
+    assert_eq!(client.resolve(&hash), (owner.clone(), None));
+
+    client.set_privacy_mode(&hash, &PrivacyMode::Private);
+
+    assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Private);
+    assert_eq!(client.resolve(&hash), (contract_id, None));
+}
+
+#[test]
+fn test_privacy_mode_can_be_restored_to_normal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client, root) = setup_with_root(&env);
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 42);
+    let new_root = BytesN::from_array(&env, &[43u8; 32]);
+
+    client.register(&owner, &hash);
+    client.register_resolver(
+        &owner,
+        &hash,
+        &dummy_proof(&env),
+        &PublicSignals {
+            old_root: root,
+            new_root,
+        },
+    );
+
+    client.set_privacy_mode(&hash, &PrivacyMode::Private);
+    assert_eq!(client.resolve(&hash), (contract_id, None));
+
+    client.set_privacy_mode(&hash, &PrivacyMode::Normal);
+    assert_eq!(client.resolve(&hash), (owner, None));
 }
 
 // ── resolve_stellar tests ─────────────────────────────────────────────────────

--- a/gateway-contract/contracts/core_contract/src/types.rs
+++ b/gateway-contract/contracts/core_contract/src/types.rs
@@ -22,6 +22,13 @@ pub enum ChainType {
     Cosmos,
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum PrivacyMode {
+    Normal,
+    Private,
+}
+
 /// Public signals extracted from a Groth16 non-inclusion proof.
 /// `old_root` must match the current on-chain SMT root.
 /// `new_root` becomes the new SMT root after a successful registration.


### PR DESCRIPTION
Closes #109

---

## Summary
- add a privacy mode toggle to `core_contract`
- return the contract address from `resolve` when a username is in `Private` mode
- add regression coverage for privacy-mode shielding and restoring normal resolution

## Changes
- add `PrivacyMode` to `core_contract` types
- store privacy mode through `AddressManager` with owner auth and a typed `PrivSet` event
- update `resolve` to shield the wallet address when privacy mode is enabled
- add tests for private and restored-normal resolution behavior

## Validation
- `cargo fmt --all`
- `cargo test -p core_contract privacy_mode --lib` blocked locally because this Windows machine is missing `link.exe` / Visual Studio Build Tools

## Note
This branch replaces the earlier closed PR with a clean branch that only contains the privacy-mode work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added privacy mode functionality for registered usernames.
  * Users can now set privacy mode to Private or Normal; when set to Private, name resolution returns the contract address instead of the registered wallet address.
  * Includes getter and setter methods for managing privacy mode.

* **Tests**
  * Added unit tests validating privacy mode resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->