### PR TITLE
feat(core-contract): implement privacy mode storage

### DIFF
--- a/gateway-contract/contracts/core_contract/src/address_manager.rs
+++ b/gateway-contract/contracts/core_contract/src/address_manager.rs
@@ -1,30 +1,14 @@
-use soroban_sdk::{
-    contracterror, contractevent, contracttype, panic_with_error, Address, Bytes, BytesN, Env,
-};
+use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, BytesN, Env};
 
 use crate::errors::ChainAddressError;
 use crate::events::{CHAIN_ADD, CHAIN_REM};
-use crate::registration::{DataKey as CommitmentKey, Registration};
-use crate::types::{ChainType, PrivacyMode};
+use crate::registration::DataKey as CommitmentKey;
+use crate::types::ChainType;
 
 #[contracttype]
 #[derive(Clone)]
 pub enum ChainAddrKey {
     ChainAddress(BytesN<32>, ChainType),
-    Privacy(BytesN<32>),
-}
-
-#[contractevent]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PrivSet {
-    pub username_hash: BytesN<32>,
-    pub mode: u32,
-}
-
-#[contracterror]
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub enum AddressManagerError {
-    UsernameNotRegistered = 1,
 }
 
 pub struct AddressManager;
@@ -95,34 +79,6 @@ impl AddressManager {
 
         #[allow(deprecated)]
         env.events().publish((CHAIN_REM,), (username_hash, chain));
-    }
-
-    pub fn set_privacy_mode(env: Env, username_hash: BytesN<32>, mode: PrivacyMode) {
-        let owner = Registration::get_owner(env.clone(), username_hash.clone())
-            .unwrap_or_else(|| panic_with_error!(&env, AddressManagerError::UsernameNotRegistered));
-
-        owner.require_auth();
-
-        let key = ChainAddrKey::Privacy(username_hash.clone());
-        env.storage().persistent().set(&key, &mode);
-
-        let mode_val: u32 = match mode {
-            PrivacyMode::Normal => 0,
-            PrivacyMode::Private => 1,
-        };
-        PrivSet {
-            username_hash,
-            mode: mode_val,
-        }
-        .publish(&env);
-    }
-
-    pub fn get_privacy_mode(env: Env, username_hash: BytesN<32>) -> PrivacyMode {
-        let key = ChainAddrKey::Privacy(username_hash);
-        env.storage()
-            .persistent()
-            .get(&key)
-            .unwrap_or(PrivacyMode::Normal)
     }
 
     fn validate_address(chain: &ChainType, address: &Bytes) -> bool {

--- a/gateway-contract/contracts/core_contract/src/events.rs
+++ b/gateway-contract/contracts/core_contract/src/events.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 
-use soroban_sdk::{symbol_short, Symbol};
+use soroban_sdk::{symbol_short, Env, Symbol};
 
 pub const INIT_EVENT: Symbol = symbol_short!("INIT");
 pub const TRANSFER_EVENT: Symbol = symbol_short!("TRANSFER");
@@ -10,8 +10,11 @@ pub const MASTER_SET: Symbol = symbol_short!("MSTR_SET");
 pub const ADDR_ADDED: Symbol = symbol_short!("ADDR_ADD");
 pub const CHAIN_ADD: Symbol = symbol_short!("CHAIN_ADD");
 pub const CHAIN_REM: Symbol = symbol_short!("CHAIN_REM");
-pub const PRIV_SET: Symbol = symbol_short!("PRIV_SET");
 pub const VAULT_CREATE: Symbol = symbol_short!("VAULT_CRT");
 pub const DEPOSIT: Symbol = symbol_short!("DEPOSIT");
 pub const WITHDRAW: Symbol = symbol_short!("WITHDRAW");
 pub const SCHED_PAY: Symbol = symbol_short!("SCHED_PAY");
+
+pub fn privacy_set_event(env: &Env) -> Symbol {
+    Symbol::new(env, "PRIVACY_SET")
+}

--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -14,7 +14,7 @@ mod test;
 
 use address_manager::AddressManager;
 use errors::CoreError;
-use events::{REGISTER_EVENT, TRANSFER_EVENT};
+use events::{privacy_set_event, REGISTER_EVENT, TRANSFER_EVENT};
 use registration::Registration;
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Bytes, BytesN, Env};
 use types::{ChainType, PrivacyMode, PublicSignals, ResolveData};
@@ -80,11 +80,19 @@ impl Contract {
     }
 
     pub fn set_privacy_mode(env: Env, username_hash: BytesN<32>, mode: PrivacyMode) {
-        AddressManager::set_privacy_mode(env, username_hash, mode);
+        let owner = Registration::get_owner(env.clone(), username_hash.clone())
+            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
+        owner.require_auth();
+
+        storage::set_privacy_mode(&env, &username_hash, &mode);
+
+        #[allow(deprecated)]
+        env.events()
+            .publish((privacy_set_event(&env),), (username_hash, mode));
     }
 
     pub fn get_privacy_mode(env: Env, username_hash: BytesN<32>) -> PrivacyMode {
-        AddressManager::get_privacy_mode(env, username_hash)
+        storage::get_privacy_mode(&env, &username_hash)
     }
 
     pub fn resolve(env: Env, commitment: BytesN<32>) -> (Address, Option<u64>) {
@@ -94,8 +102,7 @@ impl Contract {
             .get::<storage::DataKey, ResolveData>(&storage::DataKey::Resolver(commitment.clone()))
         {
             Some(data) => {
-                if AddressManager::get_privacy_mode(env.clone(), commitment) == PrivacyMode::Private
-                {
+                if storage::get_privacy_mode(&env, &commitment) == PrivacyMode::Shielded {
                     (env.current_contract_address(), data.memo)
                 } else {
                     (data.wallet, data.memo)

--- a/gateway-contract/contracts/core_contract/src/storage.rs
+++ b/gateway-contract/contracts/core_contract/src/storage.rs
@@ -1,4 +1,6 @@
-use soroban_sdk::{contracttype, BytesN};
+use soroban_sdk::{contracttype, BytesN, Env};
+
+use crate::types::PrivacyMode;
 
 /// Storage keys for the Core contract's persistent and instance storage.
 #[contracttype]
@@ -10,4 +12,19 @@ pub enum DataKey {
     SmtRoot,
     /// Key for the primary Stellar address linked to a username hash.
     StellarAddress(BytesN<32>),
+    /// Key for the user's selected privacy mode.
+    PrivacyMode(BytesN<32>),
+}
+
+pub fn set_privacy_mode(env: &Env, username_hash: &BytesN<32>, mode: &PrivacyMode) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::PrivacyMode(username_hash.clone()), mode);
+}
+
+pub fn get_privacy_mode(env: &Env, username_hash: &BytesN<32>) -> PrivacyMode {
+    env.storage()
+        .persistent()
+        .get::<DataKey, PrivacyMode>(&DataKey::PrivacyMode(username_hash.clone()))
+        .unwrap_or(PrivacyMode::Normal)
 }

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -8,7 +8,7 @@ use escrow_contract::types::{
     AutoPay, ScheduledPayment as EscrowScheduledPayment, VaultConfig, VaultState,
 };
 use soroban_sdk::testutils::{Address as _, Events, MockAuth, MockAuthInvoke};
-use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, IntoVal, Symbol};
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, IntoVal, Symbol, Val, Vec};
 
 fn setup(env: &Env) -> (Address, ContractClient<'_>) {
     let contract_id = env.register(Contract, ());
@@ -317,7 +317,7 @@ fn test_set_privacy_mode_non_owner_rejected() {
             .set(&RegistrationKey::Commitment(hash.clone()), &owner);
     });
 
-    let args = (hash.clone(), PrivacyMode::Shielded).into_val(&env);
+    let args: Vec<Val> = (hash.clone(), PrivacyMode::Shielded).into_val(&env);
     env.mock_auths(&[MockAuth {
         address: &attacker,
         invoke: &MockAuthInvoke {

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -1,13 +1,14 @@
 #![cfg(test)]
 
+use crate::registration::DataKey as RegistrationKey;
 use crate::smt_root::SmtRoot;
 use crate::types::{AddressMetadata, ChainType, PrivacyMode, PublicSignals};
 use crate::{Contract, ContractClient};
 use escrow_contract::types::{
     AutoPay, ScheduledPayment as EscrowScheduledPayment, VaultConfig, VaultState,
 };
-use soroban_sdk::testutils::{Address as _, Events};
-use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, Symbol};
+use soroban_sdk::testutils::{Address as _, Events, MockAuth, MockAuthInvoke};
+use soroban_sdk::{contracttype, Address, Bytes, BytesN, Env, IntoVal, Symbol};
 
 fn setup(env: &Env) -> (Address, ContractClient<'_>) {
     let contract_id = env.register(Contract, ());
@@ -237,7 +238,17 @@ fn test_set_memo_and_resolve_flow() {
 }
 
 #[test]
-fn test_privacy_mode_resolve_shields_registered_wallet() {
+fn test_get_privacy_mode_defaults_to_normal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+    let hash = commitment(&env, 39);
+
+    assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Normal);
+}
+
+#[test]
+fn test_set_privacy_mode_to_shielded() {
     let env = Env::default();
     env.mock_all_auths();
     let (contract_id, client, root) = setup_with_root(&env);
@@ -259,17 +270,17 @@ fn test_privacy_mode_resolve_shields_registered_wallet() {
     assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Normal);
     assert_eq!(client.resolve(&hash), (owner.clone(), None));
 
-    client.set_privacy_mode(&hash, &PrivacyMode::Private);
+    client.set_privacy_mode(&hash, &PrivacyMode::Shielded);
 
-    assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Private);
+    assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Shielded);
     assert_eq!(client.resolve(&hash), (contract_id, None));
 }
 
 #[test]
-fn test_privacy_mode_can_be_restored_to_normal() {
+fn test_set_privacy_mode_to_normal() {
     let env = Env::default();
     env.mock_all_auths();
-    let (contract_id, client, root) = setup_with_root(&env);
+    let (_, client, root) = setup_with_root(&env);
     let owner = Address::generate(&env);
     let hash = commitment(&env, 42);
     let new_root = BytesN::from_array(&env, &[43u8; 32]);
@@ -285,11 +296,46 @@ fn test_privacy_mode_can_be_restored_to_normal() {
         },
     );
 
-    client.set_privacy_mode(&hash, &PrivacyMode::Private);
-    assert_eq!(client.resolve(&hash), (contract_id, None));
+    client.set_privacy_mode(&hash, &PrivacyMode::Shielded);
+    assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Shielded);
 
     client.set_privacy_mode(&hash, &PrivacyMode::Normal);
-    assert_eq!(client.resolve(&hash), (owner, None));
+    assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Normal);
+}
+
+#[test]
+fn test_set_privacy_mode_non_owner_rejected() {
+    let env = Env::default();
+    let (contract_id, client) = setup(&env);
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let hash = commitment(&env, 44);
+
+    env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .set(&RegistrationKey::Commitment(hash.clone()), &owner);
+    });
+
+    let args = (hash.clone(), PrivacyMode::Shielded).into_val(&env);
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "set_privacy_mode",
+            args: args.clone(),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = env.try_invoke_contract::<(), soroban_sdk::Error>(
+        &contract_id,
+        &Symbol::new(&env, "set_privacy_mode"),
+        args,
+    );
+
+    assert!(result.is_err());
+    assert_eq!(client.get_privacy_mode(&hash), PrivacyMode::Normal);
 }
 
 // ── resolve_stellar tests ─────────────────────────────────────────────────────

--- a/gateway-contract/contracts/core_contract/src/types.rs
+++ b/gateway-contract/contracts/core_contract/src/types.rs
@@ -26,7 +26,7 @@ pub enum ChainType {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PrivacyMode {
     Normal,
-    Private,
+    Shielded,
 }
 
 /// Public signals extracted from a Groth16 non-inclusion proof.


### PR DESCRIPTION
## Summary
This PR implements username-level privacy mode storage in the core contract and exposes it through contract entry points so the resolver can distinguish between normal and shielded resolution behavior.

The issue is that the core contract did not match the current project plan for user-selectable privacy mode. The contract needed a stable enum, persistent storage keyed by username hash, an owner-only setter, a getter with a sane default, and an explicit event that downstream SDK and resolver integrations can observe.

## Root Cause
The upstream contract already had partial privacy-mode behavior, but it did not match the issue requirements cleanly. The enum used `Private` instead of `Shielded`, privacy-mode persistence was not modeled in `storage.rs`, and the emitted event name did not match the required `PRIVACY_SET` topic. The existing tests also did not explicitly cover the non-owner rejection path required by the issue.

## What Changed
The `PrivacyMode` enum now uses `Normal` and `Shielded` in `types.rs`. Privacy-mode persistence was moved into `storage.rs` with a dedicated `DataKey::PrivacyMode` entry and helper functions for reading and writing the preference. In `lib.rs`, `set_privacy_mode` now resolves the registered owner for the username hash, requires that owner's auth, stores the selected mode, and emits a `PRIVACY_SET` event. `get_privacy_mode` now reads from storage and defaults to `Normal` when nothing has been stored yet. Resolver behavior was updated to treat `Shielded` mode as the signal to return the contract address instead of the public wallet.

The old privacy-mode code was removed from `address_manager.rs` so chain-address helpers and privacy-mode storage are no longer mixed together. `events.rs` now provides a runtime `PRIVACY_SET` symbol so the full required event name can be emitted.

## Validation
I added focused tests for the required behavior:

- default privacy mode resolves to `Normal`
- setting privacy mode to `Shielded` stores and returns the shielded preference
- setting privacy mode back to `Normal` stores and returns the normal preference
- a non-owner invocation of `set_privacy_mode` is rejected and leaves the stored mode unchanged

I also ran `cargo fmt` successfully.

I attempted to run `cargo test -p core_contract`, but the local machine is missing the MSVC linker (`link.exe`), so Rust compilation cannot complete in this environment. CI should perform the first full `cargo test` run for this branch.

Closes #194.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Privacy mode terminology updated from "Private" to "Shielded"
  * Privacy settings now persist in contract storage and emit a dedicated privacy event
  * Changing privacy mode requires owner authorization

* **Tests**
  * Added tests for default privacy mode, transitions between Shielded/Normal, and unauthorized attempts to change privacy mode
<!-- end of auto-generated comment: release notes by coderabbit.ai -->