### PR TITLE
feat: storage helpers for username record

### DIFF
--- a/gateway-contract/contracts/factory_contract/src/lib.rs
+++ b/gateway-contract/contracts/factory_contract/src/lib.rs
@@ -13,8 +13,8 @@ use soroban_sdk::{contract, contractimpl, panic_with_error, Address, BytesN, Env
 use crate::errors::FactoryError;
 use crate::events::emit_username_deployed;
 use crate::storage::{
-    get_auction_contract, get_core_contract, get_username_record, set_auction_contract,
-    set_core_contract, set_username_record,
+    get_auction_contract, get_core_contract, get_username, has_username, set_auction_contract,
+    set_core_contract, set_username,
 };
 use crate::types::UsernameRecord;
 
@@ -35,7 +35,7 @@ impl FactoryContract {
         };
         auction_contract.require_auth();
 
-        if get_username_record(&env, &username_hash).is_some() {
+        if has_username(&env, &username_hash) {
             panic_with_error!(&env, FactoryError::AlreadyDeployed);
         }
 
@@ -51,7 +51,7 @@ impl FactoryContract {
             core_contract,
         };
 
-        set_username_record(&env, &record);
+        set_username(&env, &record.username_hash.clone(), &record);
         emit_username_deployed(
             &env,
             &record.username_hash,
@@ -61,7 +61,7 @@ impl FactoryContract {
     }
 
     pub fn get_username_record(env: Env, username_hash: BytesN<32>) -> Option<UsernameRecord> {
-        get_username_record(&env, &username_hash)
+        get_username(&env, &username_hash)
     }
 
     /// Returns the owner of a deployed username, or `None` if not registered.
@@ -69,7 +69,7 @@ impl FactoryContract {
     /// **Complexity**: O(1) — single persistent storage lookup.
     /// **Auth**: none — read-only, safe for public polling.
     pub fn get_username_owner(env: Env, username_hash: BytesN<32>) -> Option<Address> {
-        get_username_record(&env, &username_hash).map(|r| r.owner)
+        get_username(&env, &username_hash).map(|r| r.owner)
     }
 
     pub fn get_auction_contract(env: Env) -> Option<Address> {

--- a/gateway-contract/contracts/factory_contract/src/storage.rs
+++ b/gateway-contract/contracts/factory_contract/src/storage.rs
@@ -60,7 +60,5 @@ pub fn get_config(env: &Env) -> Option<DeployConfig> {
 }
 
 pub fn set_config(env: &Env, config: &DeployConfig) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::Config, config);
+    env.storage().persistent().set(&DataKey::Config, config);
 }

--- a/gateway-contract/contracts/factory_contract/src/storage.rs
+++ b/gateway-contract/contracts/factory_contract/src/storage.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{contracttype, Address, BytesN, Env};
 
-use crate::types::UsernameRecord;
+use crate::types::{DeployConfig, UsernameRecord};
 
 #[contracttype]
 #[derive(Clone)]
@@ -8,6 +8,7 @@ pub enum DataKey {
     AuctionContract,
     CoreContract,
     Username(BytesN<32>),
+    Config,
 }
 
 pub fn set_auction_contract(env: &Env, auction_contract: &Address) {
@@ -34,14 +35,32 @@ pub fn get_core_contract(env: &Env) -> Option<Address> {
         .get::<DataKey, Address>(&DataKey::CoreContract)
 }
 
-pub fn set_username_record(env: &Env, record: &UsernameRecord) {
+pub fn set_username(env: &Env, hash: &BytesN<32>, record: &UsernameRecord) {
     env.storage()
         .persistent()
-        .set(&DataKey::Username(record.username_hash.clone()), record);
+        .set(&DataKey::Username(hash.clone()), record);
 }
 
-pub fn get_username_record(env: &Env, username_hash: &BytesN<32>) -> Option<UsernameRecord> {
+pub fn get_username(env: &Env, hash: &BytesN<32>) -> Option<UsernameRecord> {
     env.storage()
         .persistent()
-        .get::<DataKey, UsernameRecord>(&DataKey::Username(username_hash.clone()))
+        .get::<DataKey, UsernameRecord>(&DataKey::Username(hash.clone()))
+}
+
+pub fn has_username(env: &Env, hash: &BytesN<32>) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::Username(hash.clone()))
+}
+
+pub fn get_config(env: &Env) -> Option<DeployConfig> {
+    env.storage()
+        .persistent()
+        .get::<DataKey, DeployConfig>(&DataKey::Config)
+}
+
+pub fn set_config(env: &Env, config: &DeployConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Config, config);
 }


### PR DESCRIPTION
## Summary

Implements persistent storage helpers for the factory contract as specified in #105.

- Added `Config` variant to the `DataKey` enum alongside the existing `Username(BytesN<32>)` variant
- Renamed `set_username_record` / `get_username_record` to `set_username` / `get_username` to match the canonical spec
- Added `has_username(env, hash) -> bool` for existence checks using `.has()` on persistent storage
- Added `get_config(env) -> Option<DeployConfig>` and `set_config(env, config)` backed by `DataKey::Config` in persistent storage
- Added `DeployConfig` to storage imports from `crate::types`
- Updated all call sites and imports in `lib.rs` to reflect the renamed functions — replaced the `.is_some()` existence check with `has_username` for clarity

All helpers use `env.storage().persistent()` as required. `cargo build` passes with no errors.

Closes #105



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Faster, more reliable username registration and lookup flow to reduce failed registrations and improve responsiveness.
  * Streamlined internal data persistence for username records, improving consistency of public reads.

* **New Features**
  * Added deploy configuration storage so deployment settings can be saved and retrieved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->