### PR TITLE
feat(zk): add MerkleProofGenerator for inclusion and non-inclusio…

### DIFF
--- a/zk/package.json
+++ b/zk/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "verify:proof": "ts-node scripts/verify_proof.ts",
     "test:verify": "ts-node tests/test_verify_proof.ts",
+    "test:sdk": "node --test -r ts-node/register sdk/src/__tests__/proof.test.ts",
   "test": "node tests/test_update_proof.js && node tests/test_non_inclusion_proof.js",
   "test:update_proof": "node tests/test_update_proof.js",
   "test:non_inclusion": "node tests/test_non_inclusion_proof.js",

--- a/zk/sdk/src/__tests__/proof.test.ts
+++ b/zk/sdk/src/__tests__/proof.test.ts
@@ -1,0 +1,181 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+
+import { buildPoseidon } from "circomlibjs";
+import snarkjs from "snarkjs";
+
+import { MerkleProofGenerator } from "../proof";
+import type { InclusionInput, MerkleProofGeneratorConfig, NonInclusionInput } from "../types";
+
+const LEVELS = 20;
+const BUILD_DIR = path.resolve(__dirname, "../../../build");
+
+const config: MerkleProofGeneratorConfig = {
+  inclusion: {
+    wasmPath: path.join(
+      BUILD_DIR,
+      "merkle_inclusion",
+      "wasm",
+      "merkle_inclusion_js",
+      "merkle_inclusion.wasm",
+    ),
+    zkeyPath: path.join(BUILD_DIR, "merkle_inclusion", "merkle_inclusion_final.zkey"),
+  },
+  nonInclusion: {
+    wasmPath: path.join(
+      BUILD_DIR,
+      "merkle_non_inclusion",
+      "wasm",
+      "merkle_non_inclusion_js",
+      "merkle_non_inclusion.wasm",
+    ),
+    zkeyPath: path.join(BUILD_DIR, "merkle_non_inclusion", "merkle_non_inclusion_final.zkey"),
+  },
+};
+
+const missingArtifacts = [
+  config.inclusion.wasmPath,
+  config.inclusion.zkeyPath,
+  config.nonInclusion.wasmPath,
+  config.nonInclusion.zkeyPath,
+].filter((artifactPath) => !fs.existsSync(artifactPath));
+
+test(
+  "MerkleProofGenerator.proveInclusion generates a verifiable proof",
+  { skip: missingArtifacts.length > 0 ? `Missing circuit artifacts: ${missingArtifacts.join(", ")}` : false },
+  async () => {
+    const poseidon = await buildPoseidon();
+    const emptyHashes = await buildEmptyHashes(poseidon, LEVELS);
+    const { username, usernameHash } = findValidUsername(poseidon);
+    const pathElements = emptyHashes.slice(0, LEVELS);
+    const pathIndices = new Array<number>(LEVELS).fill(0);
+    const root = computeRoot(poseidon, usernameHash, pathElements, pathIndices);
+
+    const generator = new MerkleProofGenerator(config);
+    const result = await generator.proveInclusion({
+      username: username.map(toSignalString),
+      pathElements: pathElements.map(toSignalString),
+      pathIndices,
+      root: root.toString(),
+    } satisfies InclusionInput);
+
+    const verificationKey = await snarkjs.zKey.exportVerificationKey(config.inclusion.zkeyPath);
+    const isValid = await snarkjs.groth16.verify(verificationKey, result.publicSignals, result.proof);
+
+    assert.equal(isValid, true);
+    assert.deepEqual(result.publicSignals, [root.toString(), root.toString()]);
+  },
+);
+
+test(
+  "MerkleProofGenerator.proveNonInclusion generates a verifiable proof",
+  { skip: missingArtifacts.length > 0 ? `Missing circuit artifacts: ${missingArtifacts.join(", ")}` : false },
+  async () => {
+    const poseidon = await buildPoseidon();
+    const emptyHashes = await buildEmptyHashes(poseidon, LEVELS);
+    const { username, usernameHash } = findValidUsername(poseidon);
+    const leafBefore = usernameHash - 1n;
+    const leafAfter = usernameHash + 1n;
+
+    const merklePathBeforeIndices = new Array<number>(LEVELS).fill(0);
+    const merklePathAfterIndices = new Array<number>(LEVELS).fill(0);
+    merklePathAfterIndices[0] = 1;
+
+    const merklePathBeforeSiblings = emptyHashes.slice(0, LEVELS);
+    const merklePathAfterSiblings = emptyHashes.slice(0, LEVELS);
+    merklePathBeforeSiblings[0] = leafAfter;
+    merklePathAfterSiblings[0] = leafBefore;
+
+    const root = computeRoot(poseidon, leafBefore, merklePathBeforeSiblings, merklePathBeforeIndices);
+
+    const generator = new MerkleProofGenerator(config);
+    const result = await generator.proveNonInclusion({
+      username: username.map(toSignalString),
+      leaf_before: leafBefore.toString(),
+      leaf_after: leafAfter.toString(),
+      merklePathBeforeSiblings: merklePathBeforeSiblings.map(toSignalString),
+      merklePathBeforeIndices,
+      merklePathAfterSiblings: merklePathAfterSiblings.map(toSignalString),
+      merklePathAfterIndices,
+      root: root.toString(),
+    } satisfies NonInclusionInput);
+
+    const verificationKey = await snarkjs.zKey.exportVerificationKey(config.nonInclusion.zkeyPath);
+    const isValid = await snarkjs.groth16.verify(verificationKey, result.publicSignals, result.proof);
+
+    assert.equal(isValid, true);
+    assert.deepEqual(result.publicSignals, [root.toString(), root.toString(), "1"]);
+  },
+);
+
+type Poseidon = Awaited<ReturnType<typeof buildPoseidon>>;
+
+async function buildEmptyHashes(poseidon: Poseidon, depth: number): Promise<bigint[]> {
+  const hashes = [0n];
+
+  for (let index = 0; index < depth; index += 1) {
+    hashes.push(poseidon.F.toObject(poseidon([hashes[index], hashes[index]])));
+  }
+
+  return hashes;
+}
+
+function computeRoot(
+  poseidon: Poseidon,
+  leaf: bigint,
+  siblings: bigint[],
+  indices: number[],
+): bigint {
+  return siblings.reduce<bigint>((current, sibling, index) => {
+    const inputs = indices[index] === 0 ? [current, sibling] : [sibling, current];
+    return poseidon.F.toObject(poseidon(inputs));
+  }, leaf);
+}
+
+function findValidUsername(poseidon: Poseidon): { username: bigint[]; usernameHash: bigint } {
+  const limit = 1n << 252n;
+
+  for (let candidate = 1n; candidate < 5000n; candidate += 1n) {
+    const username = new Array<bigint>(32).fill(0n);
+    username[0] = candidate;
+    const usernameHash = hashUsername(poseidon, username);
+
+    if (usernameHash > 1n && usernameHash < limit - 2n) {
+      return { username, usernameHash };
+    }
+  }
+
+  throw new Error("Unable to find a username hash within the non-inclusion circuit range");
+}
+
+function hashUsername(poseidon: Poseidon, username: bigint[]): bigint {
+  const levelOne = Array.from({ length: 8 }, (_, chunkIndex) =>
+    poseidon.F.toObject(
+      poseidon([
+        username[chunkIndex * 4],
+        username[chunkIndex * 4 + 1],
+        username[chunkIndex * 4 + 2],
+        username[chunkIndex * 4 + 3],
+      ]),
+    ),
+  );
+
+  const levelTwo = Array.from({ length: 2 }, (_, chunkIndex) =>
+    poseidon.F.toObject(
+      poseidon([
+        levelOne[chunkIndex * 4],
+        levelOne[chunkIndex * 4 + 1],
+        levelOne[chunkIndex * 4 + 2],
+        levelOne[chunkIndex * 4 + 3],
+      ]),
+    ),
+  );
+
+  return poseidon.F.toObject(poseidon(levelTwo));
+}
+
+function toSignalString(value: bigint): string {
+  return value.toString();
+}

--- a/zk/sdk/src/index.ts
+++ b/zk/sdk/src/index.ts
@@ -1,0 +1,13 @@
+export { MerkleProofGenerator } from "./proof";
+export type {
+  CircuitArtifactPaths,
+  Groth16Proof,
+  InclusionInput,
+  InclusionProofResult,
+  InclusionPublicSignals,
+  MerkleProofGeneratorConfig,
+  NonInclusionInput,
+  NonInclusionProofResult,
+  NonInclusionPublicSignals,
+  SignalInput,
+} from "./types";

--- a/zk/sdk/src/proof.ts
+++ b/zk/sdk/src/proof.ts
@@ -1,0 +1,57 @@
+import snarkjs from "snarkjs";
+
+import type {
+  Groth16Proof,
+  InclusionInput,
+  InclusionProofResult,
+  MerkleProofGeneratorConfig,
+  NonInclusionInput,
+  NonInclusionProofResult,
+  SignalInput,
+} from "./types";
+
+type NormalizedSignal = string | NormalizedSignal[] | { [key: string]: NormalizedSignal };
+
+export class MerkleProofGenerator {
+  public constructor(private readonly config: MerkleProofGeneratorConfig) {}
+
+  public async proveInclusion(input: InclusionInput): Promise<InclusionProofResult> {
+    const { proof, publicSignals } = await snarkjs.groth16.fullProve(
+      normalizeInput(input),
+      this.config.inclusion.wasmPath,
+      this.config.inclusion.zkeyPath,
+    );
+
+    return {
+      proof: proof as Groth16Proof,
+      publicSignals: publicSignals as InclusionProofResult["publicSignals"],
+    };
+  }
+
+  public async proveNonInclusion(input: NonInclusionInput): Promise<NonInclusionProofResult> {
+    const { proof, publicSignals } = await snarkjs.groth16.fullProve(
+      normalizeInput(input),
+      this.config.nonInclusion.wasmPath,
+      this.config.nonInclusion.zkeyPath,
+    );
+
+    return {
+      proof: proof as Groth16Proof,
+      publicSignals: publicSignals as NonInclusionProofResult["publicSignals"],
+    };
+  }
+}
+
+function normalizeInput<T extends Record<string, SignalInput | SignalInput[]>>(input: T): Record<string, NormalizedSignal> {
+  return Object.fromEntries(
+    Object.entries(input).map(([key, value]) => [key, normalizeSignal(value)]),
+  );
+}
+
+function normalizeSignal(value: SignalInput | SignalInput[]): NormalizedSignal {
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeSignal(entry));
+  }
+
+  return typeof value === "bigint" ? value.toString() : String(value);
+}

--- a/zk/sdk/src/types.ts
+++ b/zk/sdk/src/types.ts
@@ -1,0 +1,50 @@
+export type SignalInput = string | number | bigint;
+
+export interface CircuitArtifactPaths {
+  wasmPath: string;
+  zkeyPath: string;
+}
+
+export interface MerkleProofGeneratorConfig {
+  inclusion: CircuitArtifactPaths;
+  nonInclusion: CircuitArtifactPaths;
+}
+
+export interface InclusionInput {
+  username: SignalInput[];
+  pathElements: SignalInput[];
+  pathIndices: SignalInput[];
+  root: SignalInput;
+}
+
+export interface NonInclusionInput {
+  username: SignalInput[];
+  leaf_before: SignalInput;
+  leaf_after: SignalInput;
+  merklePathBeforeSiblings: SignalInput[];
+  merklePathBeforeIndices: SignalInput[];
+  merklePathAfterSiblings: SignalInput[];
+  merklePathAfterIndices: SignalInput[];
+  root: SignalInput;
+}
+
+export interface Groth16Proof {
+  pi_a: string[];
+  pi_b: string[][];
+  pi_c: string[];
+  protocol: string;
+  curve: string;
+}
+
+export type InclusionPublicSignals = [root: string, outRoot: string];
+export type NonInclusionPublicSignals = [root: string, outRoot: string, isAvailable: string];
+
+export interface InclusionProofResult {
+  proof: Groth16Proof;
+  publicSignals: InclusionPublicSignals;
+}
+
+export interface NonInclusionProofResult {
+  proof: Groth16Proof;
+  publicSignals: NonInclusionPublicSignals;
+}


### PR DESCRIPTION
feat(zk-sdk): add MerkleProofGenerator for inclusion and non-inclusion proofs

closed #197 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Proof generation API supporting Merkle tree inclusion and non-inclusion verification with separate configuration for each circuit type.
  * Generate and verify Groth16 cryptographic proofs with automatic signal normalization and public signal validation.
  * TypeScript type definitions for all proof inputs, outputs, and configuration objects.

* **Tests**
  * New test suite covering proof generation and verification workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->