### PR TITLE
feat(escrow): add get_balance read-only vault balance getter

### DIFF
--- a/gateway-contract/contracts/escrow_contract/src/lib.rs
+++ b/gateway-contract/contracts/escrow_contract/src/lib.rs
@@ -262,6 +262,21 @@ impl EscrowContract {
             current_time,
         );
     }
+
+    /// Returns the current balance of a vault identified by its commitment.
+    ///
+    /// This is a read-only getter with no side effects and no authentication
+    /// requirement. It performs a single O(1) persistent-storage lookup.
+    ///
+    /// ### Arguments
+    /// - `commitment`: The `BytesN<32>` identifier of the vault.
+    ///
+    /// ### Returns
+    /// - `None` if the vault does not exist.
+    /// - `Some(balance)` with the vault's current available balance.
+    pub fn get_balance(env: Env, commitment: BytesN<32>) -> Option<i128> {
+        read_vault_state(&env, &commitment).map(|state| state.balance)
+    }
 }
 
 fn resolve(env: &Env, commitment: &BytesN<32>) -> Address {

--- a/gateway-contract/contracts/escrow_contract/src/test.rs
+++ b/gateway-contract/contracts/escrow_contract/src/test.rs
@@ -382,14 +382,7 @@ fn test_get_balance_after_payment() {
         &token,
         initial,
     );
-    create_vault(
-        &env,
-        &contract_id,
-        &to,
-        &Address::generate(&env),
-        &token,
-        0,
-    );
+    create_vault(&env, &contract_id, &to, &Address::generate(&env), &token, 0);
 
     env.ledger().set_timestamp(1000);
     client.schedule_payment(&from, &to, &amount, &2000);

--- a/gateway-contract/contracts/escrow_contract/src/test.rs
+++ b/gateway-contract/contracts/escrow_contract/src/test.rs
@@ -335,3 +335,65 @@ fn test_execute_scheduled_not_found_panics() {
         Err(Ok(err)) if err == Error::from_contract_error(EscrowError::PaymentNotFound as u32)
     ));
 }
+
+// ─── get_balance tests ───────────────────────────────────────────────
+
+#[test]
+fn test_get_balance_vault_not_found() {
+    let env = Env::default();
+    let (_, client, _, _, _, _) = setup_test(&env);
+
+    let unknown = BytesN::from_array(&env, &[99u8; 32]);
+    assert_eq!(client.get_balance(&unknown), None);
+}
+
+#[test]
+fn test_get_balance_after_deposit() {
+    let env = Env::default();
+    let (contract_id, client, token, _, from, _) = setup_test(&env);
+
+    let balance = 5_000i128;
+    create_vault(
+        &env,
+        &contract_id,
+        &from,
+        &Address::generate(&env),
+        &token,
+        balance,
+    );
+
+    assert_eq!(client.get_balance(&from), Some(balance));
+}
+
+#[test]
+fn test_get_balance_after_payment() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client, token, _, from, to) = setup_test(&env);
+
+    let initial = 1_000i128;
+    let amount = 300i128;
+
+    create_vault(
+        &env,
+        &contract_id,
+        &from,
+        &Address::generate(&env),
+        &token,
+        initial,
+    );
+    create_vault(
+        &env,
+        &contract_id,
+        &to,
+        &Address::generate(&env),
+        &token,
+        0,
+    );
+
+    env.ledger().set_timestamp(1000);
+    client.schedule_payment(&from, &to, &amount, &2000);
+
+    // Balance should reflect the reserved funds
+    assert_eq!(client.get_balance(&from), Some(initial - amount));
+}


### PR DESCRIPTION
Closes #191 

- Add get_balance(commitment) -> Option<i128> to EscrowContract
- Returns None for unregistered vaults, Some(balance) for existing ones
- No auth required, O(1) persistent-storage lookup, no side effects
- Add tests: vault not found, balance after deposit, balance after payment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a balance query so users can retrieve a vault's current balance or see when a vault does not exist.

* **Tests**
  * Added tests covering unknown vaults, seeded vault balances after deposit, and balance changes after scheduling a payment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->