### PR TITLE
fix/feat: AutoPay key isolation, core initialize, shielded address, ZK range check

### DIFF
--- a/gateway-contract/contracts/core_contract/src/errors.rs
+++ b/gateway-contract/contracts/core_contract/src/errors.rs
@@ -20,6 +20,8 @@ pub enum CoreError {
     Unauthorized = 7,
     /// new_owner is the same as the current owner.
     SameOwner = 8,
+    /// initialize() has already been called on this contract instance.
+    AlreadyInitialized = 9,
 }
 
 #[contracterror]

--- a/gateway-contract/contracts/core_contract/src/events.rs
+++ b/gateway-contract/contracts/core_contract/src/events.rs
@@ -18,3 +18,7 @@ pub const SCHED_PAY: Symbol = symbol_short!("SCHED_PAY");
 pub fn privacy_set_event(env: &Env) -> Symbol {
     Symbol::new(env, "PRIVACY_SET")
 }
+
+pub fn shielded_add_event(env: &Env) -> Symbol {
+    Symbol::new(env, "SHIELDED_ADD")
+}

--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -14,7 +14,7 @@ mod test;
 
 use address_manager::AddressManager;
 use errors::CoreError;
-use events::{privacy_set_event, REGISTER_EVENT, TRANSFER_EVENT};
+use events::{privacy_set_event, shielded_add_event, INIT_EVENT, REGISTER_EVENT, TRANSFER_EVENT};
 use registration::Registration;
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Bytes, BytesN, Env};
 use types::{ChainType, PrivacyMode, PublicSignals, ResolveData};
@@ -24,6 +24,31 @@ pub struct Contract;
 
 #[contractimpl]
 impl Contract {
+    /// Initializes the contract by setting the owner address.
+    ///
+    /// Must be called once after deployment. Panics with `AlreadyInitialized`
+    /// if called again on an already-initialized instance.
+    pub fn initialize(env: Env, owner: Address) {
+        owner.require_auth();
+
+        if storage::is_initialized(&env) {
+            panic_with_error!(&env, errors::CoreError::AlreadyInitialized);
+        }
+
+        storage::set_owner(&env, &owner);
+
+        #[allow(deprecated)]
+        env.events().publish((INIT_EVENT,), (owner,));
+    }
+
+    /// Returns the contract owner address set during `initialize`.
+    ///
+    /// Panics with `NotFound` if `initialize` has not been called yet.
+    pub fn get_contract_owner(env: Env) -> Address {
+        storage::get_owner(&env)
+            .unwrap_or_else(|| panic_with_error!(&env, errors::CoreError::NotFound))
+    }
+
     pub fn get_smt_root(env: Env) -> BytesN<32> {
         smt_root::SmtRoot::get_root(env.clone())
             .unwrap_or_else(|| panic_with_error!(&env, CoreError::RootNotSet))
@@ -254,6 +279,43 @@ impl Contract {
         #[allow(deprecated)]
         env.events()
             .publish((TRANSFER_EVENT,), (commitment, caller, new_owner));
+    }
+
+    /// Stores a ZK commitment as the shielded address for the given username.
+    ///
+    /// Only the registered owner of `username_hash` may call this function.
+    /// The raw address is never stored — only the commitment (ZK proof handle).
+    /// Emits a `SHIELDED_ADD` event on success.
+    pub fn add_shielded_address(
+        env: Env,
+        caller: Address,
+        username_hash: BytesN<32>,
+        address_commitment: BytesN<32>,
+    ) {
+        caller.require_auth();
+
+        let owner = registration::Registration::get_owner(env.clone(), username_hash.clone())
+            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
+
+        if owner != caller {
+            panic_with_error!(&env, CoreError::Unauthorized);
+        }
+
+        storage::set_shielded_address(&env, &username_hash, &address_commitment);
+
+        #[allow(deprecated)]
+        env.events()
+            .publish((shielded_add_event(&env),), (username_hash, address_commitment));
+    }
+
+    /// Returns the shielded address commitment for the given username hash, if any.
+    pub fn get_shielded_address(env: Env, username_hash: BytesN<32>) -> Option<BytesN<32>> {
+        storage::get_shielded_address(&env, &username_hash)
+    }
+
+    /// Returns `true` if a shielded address commitment has been stored for the given username hash.
+    pub fn is_shielded(env: Env, username_hash: BytesN<32>) -> bool {
+        storage::has_shielded_address(&env, &username_hash)
     }
 
     /// Resolve a username hash to its primary linked Stellar address.

--- a/gateway-contract/contracts/core_contract/src/lib.rs
+++ b/gateway-contract/contracts/core_contract/src/lib.rs
@@ -304,8 +304,10 @@ impl Contract {
         storage::set_shielded_address(&env, &username_hash, &address_commitment);
 
         #[allow(deprecated)]
-        env.events()
-            .publish((shielded_add_event(&env),), (username_hash, address_commitment));
+        env.events().publish(
+            (shielded_add_event(&env),),
+            (username_hash, address_commitment),
+        );
     }
 
     /// Returns the shielded address commitment for the given username hash, if any.

--- a/gateway-contract/contracts/core_contract/src/storage.rs
+++ b/gateway-contract/contracts/core_contract/src/storage.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, BytesN, Env};
+use soroban_sdk::{contracttype, Address, BytesN, Env};
 
 use crate::types::PrivacyMode;
 
@@ -14,6 +14,10 @@ pub enum DataKey {
     StellarAddress(BytesN<32>),
     /// Key for the user's selected privacy mode.
     PrivacyMode(BytesN<32>),
+    /// Key for the contract owner set during initialization (instance storage).
+    Owner,
+    /// Key for a shielded address commitment, indexed by username hash.
+    ShieldedAddress(BytesN<32>),
 }
 
 pub fn set_privacy_mode(env: &Env, username_hash: &BytesN<32>, mode: &PrivacyMode) {
@@ -27,4 +31,38 @@ pub fn get_privacy_mode(env: &Env, username_hash: &BytesN<32>) -> PrivacyMode {
         .persistent()
         .get::<DataKey, PrivacyMode>(&DataKey::PrivacyMode(username_hash.clone()))
         .unwrap_or(PrivacyMode::Normal)
+}
+
+pub fn set_owner(env: &Env, owner: &Address) {
+    env.storage().instance().set(&DataKey::Owner, owner);
+}
+
+pub fn get_owner(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::Owner)
+}
+
+pub fn is_initialized(env: &Env) -> bool {
+    env.storage().instance().has(&DataKey::Owner)
+}
+
+pub fn set_shielded_address(
+    env: &Env,
+    username_hash: &BytesN<32>,
+    commitment: &BytesN<32>,
+) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::ShieldedAddress(username_hash.clone()), commitment);
+}
+
+pub fn get_shielded_address(env: &Env, username_hash: &BytesN<32>) -> Option<BytesN<32>> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::ShieldedAddress(username_hash.clone()))
+}
+
+pub fn has_shielded_address(env: &Env, username_hash: &BytesN<32>) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::ShieldedAddress(username_hash.clone()))
 }

--- a/gateway-contract/contracts/core_contract/src/storage.rs
+++ b/gateway-contract/contracts/core_contract/src/storage.rs
@@ -45,11 +45,7 @@ pub fn is_initialized(env: &Env) -> bool {
     env.storage().instance().has(&DataKey::Owner)
 }
 
-pub fn set_shielded_address(
-    env: &Env,
-    username_hash: &BytesN<32>,
-    commitment: &BytesN<32>,
-) {
+pub fn set_shielded_address(env: &Env, username_hash: &BytesN<32>, commitment: &BytesN<32>) {
     env.storage()
         .persistent()
         .set(&DataKey::ShieldedAddress(username_hash.clone()), commitment);

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -1039,3 +1039,146 @@ fn test_update_root_non_owner_panics() {
 
     assert!(result.is_err());
 }
+
+// ============================================================================
+// initialize / get_contract_owner tests  (Issue #187)
+// ============================================================================
+
+#[test]
+fn test_initialize_stores_owner() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
+
+    assert_eq!(client.get_contract_owner(), owner);
+}
+
+#[test]
+fn test_initialize_emits_init_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
+
+    let events = env.events().all();
+    let has_init_event = events
+        .iter()
+        .any(|(c, _, _)| c == contract_id);
+    assert!(has_init_event);
+}
+
+#[test]
+fn test_initialize_double_init_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
+
+    let result = client.try_initialize(&owner);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_get_contract_owner_before_init_panics() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let result = client.try_get_contract_owner();
+    assert!(result.is_err());
+}
+
+// ============================================================================
+// add_shielded_address / get_shielded_address / is_shielded tests  (Issue #193)
+// ============================================================================
+
+#[test]
+fn test_add_shielded_address_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 80);
+    let addr_commitment = BytesN::from_array(&env, &[0xAAu8; 32]);
+
+    client.register(&owner, &hash);
+    client.add_shielded_address(&owner, &hash, &addr_commitment);
+
+    assert_eq!(client.get_shielded_address(&hash), Some(addr_commitment));
+    assert!(client.is_shielded(&hash));
+}
+
+#[test]
+fn test_is_shielded_returns_false_when_not_set() {
+    let env = Env::default();
+    let (_, client) = setup(&env);
+
+    let hash = commitment(&env, 81);
+    assert!(!client.is_shielded(&hash));
+}
+
+#[test]
+fn test_add_shielded_address_overwrite_works() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let hash = commitment(&env, 82);
+    let first = BytesN::from_array(&env, &[0x11u8; 32]);
+    let second = BytesN::from_array(&env, &[0x22u8; 32]);
+
+    client.register(&owner, &hash);
+    client.add_shielded_address(&owner, &hash, &first);
+    client.add_shielded_address(&owner, &hash, &second);
+
+    assert_eq!(client.get_shielded_address(&hash), Some(second));
+}
+
+#[test]
+fn test_add_shielded_address_non_owner_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let hash = commitment(&env, 83);
+    let addr_commitment = BytesN::from_array(&env, &[0xBBu8; 32]);
+
+    client.register(&owner, &hash);
+
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "add_shielded_address",
+            args: (&attacker, &hash, &addr_commitment).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_add_shielded_address(&attacker, &hash, &addr_commitment);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_add_shielded_address_unregistered_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let caller = Address::generate(&env);
+    let hash = commitment(&env, 84);
+    let addr_commitment = BytesN::from_array(&env, &[0xCCu8; 32]);
+
+    let result = client.try_add_shielded_address(&caller, &hash, &addr_commitment);
+    assert!(result.is_err());
+}

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -1066,9 +1066,7 @@ fn test_initialize_emits_init_event() {
     client.initialize(&owner);
 
     let events = env.events().all();
-    let has_init_event = events
-        .iter()
-        .any(|(c, _, _)| c == contract_id);
+    let has_init_event = events.iter().any(|(c, _, _)| c == contract_id);
     assert!(has_init_event);
 }
 

--- a/gateway-contract/contracts/escrow_contract/src/test.rs
+++ b/gateway-contract/contracts/escrow_contract/src/test.rs
@@ -538,3 +538,63 @@ fn test_get_balance_after_payment() {
     // Balance should reflect the reserved funds
     assert_eq!(client.get_balance(&from), Some(initial - amount));
 }
+
+// ─── auto-pay storage isolation tests ────────────────────────────────────────
+
+/// Registers one auto-pay rule on each of two different vaults and confirms
+/// that neither rule is visible when looking up the other vault's commitment.
+/// This validates that the composite key (commitment, rule_id) fully isolates
+/// rules across vaults even when the global rule_id counter produces the same
+/// numeric ID for each.
+#[test]
+fn test_auto_pay_multiple_vaults_no_interference() {
+    use crate::storage::{read_auto_pay, write_auto_pay};
+    use crate::types::AutoPay;
+
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, _client, token, _token_admin, _from, _to) = setup_test(&env);
+
+    let vault_a = BytesN::from_array(&env, &[0xAAu8; 32]);
+    let vault_b = BytesN::from_array(&env, &[0xBBu8; 32]);
+
+    let rule_a = AutoPay {
+        from: vault_a.clone(),
+        to: vault_b.clone(),
+        token: token.clone(),
+        amount: 100,
+        interval: 86_400,
+        last_paid: 0,
+    };
+    let rule_b = AutoPay {
+        from: vault_b.clone(),
+        to: vault_a.clone(),
+        token: token.clone(),
+        amount: 200,
+        interval: 43_200,
+        last_paid: 0,
+    };
+
+    // Both rules share rule_id = 0 (simulating the global counter starting at 0
+    // for each vault). The composite key must keep them isolated.
+    env.as_contract(&contract_id, || {
+        write_auto_pay(&env, &vault_a, 0, &rule_a);
+        write_auto_pay(&env, &vault_b, 0, &rule_b);
+    });
+
+    env.as_contract(&contract_id, || {
+        // Vault A's rule is retrievable under vault A's commitment.
+        let stored_a = read_auto_pay(&env, &vault_a, 0).expect("rule for vault_a not found");
+        assert_eq!(stored_a.amount, 100);
+        assert_eq!(stored_a.interval, 86_400);
+
+        // Vault B's rule is retrievable under vault B's commitment.
+        let stored_b = read_auto_pay(&env, &vault_b, 0).expect("rule for vault_b not found");
+        assert_eq!(stored_b.amount, 200);
+        assert_eq!(stored_b.interval, 43_200);
+
+        // Vault A's commitment does NOT return vault B's rule, and vice versa.
+        assert_ne!(stored_a.amount, stored_b.amount);
+        assert_ne!(stored_a.from, stored_b.from);
+    });
+}

--- a/zk/circuits/username_hash.circom
+++ b/zk/circuits/username_hash.circom
@@ -1,19 +1,28 @@
 pragma circom 2.0.0;
 
 include "circomlib/circuits/poseidon.circom";
+include "circomlib/circuits/comparators.circom";
 
 template UsernameHash() {
 
     // 32-character fixed username.
-    // AUDIT NOTE (F-03): Each element is an unconstrained field element.
-    // No range check enforces valid character values (e.g., 0–127 ASCII).
-    // Two distinct byte representations of the same logical username can
-    // produce different hashes, breaking uniqueness. Range checks must be
-    // enforced off-chain or via a dedicated range-check sub-circuit.
     signal input username[32];
 
     // Public output
     signal output username_hash;
+
+    // Range check: enforce each username[i] is in [0, 127] (valid ASCII).
+    // Fixes Finding F-03: without this constraint two distinct byte
+    // representations of the same logical username could produce different
+    // hashes, breaking uniqueness guarantees.
+    // LessThan(8) checks in[0] < in[1] using 8-bit arithmetic (128 < 2^8).
+    component rangeCheck[32];
+    for (var i = 0; i < 32; i++) {
+        rangeCheck[i] = LessThan(8);
+        rangeCheck[i].in[0] <== username[i];
+        rangeCheck[i].in[1] <== 128;
+        rangeCheck[i].out === 1;
+    }
 
     // Step 1: Hash in chunks of 4
     component h[8];

--- a/zk/circuits/username_hash_impl.circom
+++ b/zk/circuits/username_hash_impl.circom
@@ -1,6 +1,7 @@
 pragma circom 2.0.0;
 
 include "circomlib/circuits/poseidon.circom";
+include "circomlib/circuits/comparators.circom";
 
 template UsernameHash() {
 
@@ -9,6 +10,17 @@ template UsernameHash() {
 
     // Public output
     signal output username_hash;
+
+    // Range check: enforce each username[i] is in [0, 127] (valid ASCII).
+    // LessThan(n) checks that in[0] < in[1] using n-bit arithmetic.
+    // Using 8 bits is sufficient since 128 < 2^8.
+    component rangeCheck[32];
+    for (var i = 0; i < 32; i++) {
+        rangeCheck[i] = LessThan(8);
+        rangeCheck[i].in[0] <== username[i];
+        rangeCheck[i].in[1] <== 128;
+        rangeCheck[i].out === 1;
+    }
 
     // Step 1: Hash in chunks of 4
     component h[8];

--- a/zk/tests/test_username_range_check.js
+++ b/zk/tests/test_username_range_check.js
@@ -1,0 +1,118 @@
+"use strict";
+
+/**
+ * test_username_range_check.js
+ *
+ * Verifies that username_hash circuit enforces the [0, 127] ASCII range
+ * constraint on every username character (Fix for Finding F-03).
+ *
+ * Prerequisites (run from zk/):
+ *   npm run compile   # compiles username_hash circuit
+ *
+ * Run:
+ *   node tests/test_username_range_check.js
+ */
+
+const path = require("path");
+const assert = require("assert");
+const snarkjs = require("snarkjs");
+
+const CIRCUIT = "username_hash";
+const BUILD_DIR = path.join(__dirname, "..", "build", CIRCUIT);
+const WASM_PATH = path.join(
+  BUILD_DIR,
+  "wasm",
+  `${CIRCUIT}_js`,
+  `${CIRCUIT}.wasm`
+);
+
+/** Encodes a string into a zero-padded 32-element ASCII array. */
+function encodeUsername(str) {
+  const arr = new Array(32).fill(0);
+  for (let i = 0; i < Math.min(str.length, 32); i++) {
+    arr[i] = str.charCodeAt(i);
+  }
+  return arr;
+}
+
+async function main() {
+  console.log("=== username_hash range-check tests ===\n");
+
+  // ── Test 1: valid ASCII username should generate a witness ────────────────
+  {
+    const input = { username: encodeUsername("alice") };
+    try {
+      const { wtns } = await snarkjs.wtns.calculate(input, WASM_PATH, {});
+      assert.ok(wtns, "Witness should be generated for valid ASCII input");
+      console.log("PASS  Test 1: valid ASCII username ('alice') accepted");
+    } catch (err) {
+      console.error("FAIL  Test 1:", err.message);
+      process.exitCode = 1;
+    }
+  }
+
+  // ── Test 2: all-zero (null bytes) input should be accepted (0 <= 127) ─────
+  {
+    const input = { username: new Array(32).fill(0) };
+    try {
+      await snarkjs.wtns.calculate(input, WASM_PATH, {});
+      console.log("PASS  Test 2: all-zero username accepted (0 is valid ASCII)");
+    } catch (err) {
+      console.error("FAIL  Test 2:", err.message);
+      process.exitCode = 1;
+    }
+  }
+
+  // ── Test 3: value 127 (DEL) is the boundary — must be accepted ───────────
+  {
+    const input = { username: new Array(32).fill(127) };
+    try {
+      await snarkjs.wtns.calculate(input, WASM_PATH, {});
+      console.log("PASS  Test 3: boundary value 127 accepted");
+    } catch (err) {
+      console.error("FAIL  Test 3:", err.message);
+      process.exitCode = 1;
+    }
+  }
+
+  // ── Test 4: value 128 must be rejected by the circuit ────────────────────
+  {
+    const input = { username: new Array(32).fill(0) };
+    input.username[0] = 128; // out of range
+    try {
+      await snarkjs.wtns.calculate(input, WASM_PATH, {});
+      console.error(
+        "FAIL  Test 4: value 128 should have been rejected but was accepted"
+      );
+      process.exitCode = 1;
+    } catch (err) {
+      console.log(
+        "PASS  Test 4: value 128 correctly rejected by range constraint"
+      );
+    }
+  }
+
+  // ── Test 5: large out-of-range value (255) must be rejected ───────────────
+  {
+    const input = { username: new Array(32).fill(0) };
+    input.username[15] = 255;
+    try {
+      await snarkjs.wtns.calculate(input, WASM_PATH, {});
+      console.error(
+        "FAIL  Test 5: value 255 should have been rejected but was accepted"
+      );
+      process.exitCode = 1;
+    } catch (err) {
+      console.log(
+        "PASS  Test 5: value 255 correctly rejected by range constraint"
+      );
+    }
+  }
+
+  console.log("\n=== done ===");
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exitCode = 1;
+});

--- a/zk/tests/test_username_range_check.js
+++ b/zk/tests/test_username_range_check.js
@@ -36,83 +36,53 @@ function encodeUsername(str) {
 }
 
 async function main() {
-  console.log("=== username_hash range-check tests ===\n");
-
-  // ── Test 1: valid ASCII username should generate a witness ────────────────
+  // Test 1: valid ASCII username should generate a witness
   {
     const input = { username: encodeUsername("alice") };
-    try {
-      const { wtns } = await snarkjs.wtns.calculate(input, WASM_PATH, {});
-      assert.ok(wtns, "Witness should be generated for valid ASCII input");
-      console.log("PASS  Test 1: valid ASCII username ('alice') accepted");
-    } catch (err) {
-      console.error("FAIL  Test 1:", err.message);
-      process.exitCode = 1;
-    }
+    const { wtns } = await snarkjs.wtns.calculate(input, WASM_PATH, {});
+    assert.ok(wtns, "Witness should be generated for valid ASCII input");
   }
 
-  // ── Test 2: all-zero (null bytes) input should be accepted (0 <= 127) ─────
+  // Test 2: all-zero (null bytes) input should be accepted (0 <= 127)
   {
     const input = { username: new Array(32).fill(0) };
-    try {
-      await snarkjs.wtns.calculate(input, WASM_PATH, {});
-      console.log("PASS  Test 2: all-zero username accepted (0 is valid ASCII)");
-    } catch (err) {
-      console.error("FAIL  Test 2:", err.message);
-      process.exitCode = 1;
-    }
+    await snarkjs.wtns.calculate(input, WASM_PATH, {});
   }
 
-  // ── Test 3: value 127 (DEL) is the boundary — must be accepted ───────────
+  // Test 3: value 127 (DEL) is the boundary — must be accepted
   {
     const input = { username: new Array(32).fill(127) };
-    try {
-      await snarkjs.wtns.calculate(input, WASM_PATH, {});
-      console.log("PASS  Test 3: boundary value 127 accepted");
-    } catch (err) {
-      console.error("FAIL  Test 3:", err.message);
-      process.exitCode = 1;
-    }
+    await snarkjs.wtns.calculate(input, WASM_PATH, {});
   }
 
-  // ── Test 4: value 128 must be rejected by the circuit ────────────────────
+  // Test 4: value 128 must be rejected by the circuit
   {
     const input = { username: new Array(32).fill(0) };
-    input.username[0] = 128; // out of range
+    input.username[0] = 128;
+    let rejected = false;
     try {
       await snarkjs.wtns.calculate(input, WASM_PATH, {});
-      console.error(
-        "FAIL  Test 4: value 128 should have been rejected but was accepted"
-      );
-      process.exitCode = 1;
-    } catch (err) {
-      console.log(
-        "PASS  Test 4: value 128 correctly rejected by range constraint"
-      );
+    } catch (_) {
+      rejected = true;
     }
+    assert.ok(rejected, "Value 128 should be rejected by range constraint");
   }
 
-  // ── Test 5: large out-of-range value (255) must be rejected ───────────────
+  // Test 5: large out-of-range value (255) must be rejected
   {
     const input = { username: new Array(32).fill(0) };
     input.username[15] = 255;
+    let rejected = false;
     try {
       await snarkjs.wtns.calculate(input, WASM_PATH, {});
-      console.error(
-        "FAIL  Test 5: value 255 should have been rejected but was accepted"
-      );
-      process.exitCode = 1;
-    } catch (err) {
-      console.log(
-        "PASS  Test 5: value 255 correctly rejected by range constraint"
-      );
+    } catch (_) {
+      rejected = true;
     }
+    assert.ok(rejected, "Value 255 should be rejected by range constraint");
   }
-
-  console.log("\n=== done ===");
 }
 
 main().catch((err) => {
-  console.error("Unexpected error:", err);
+  process.stderr.write(`Unexpected error: ${err}\n`);
   process.exitCode = 1;
 });


### PR DESCRIPTION
## Description

This PR resolves four issues across the escrow contract, core contract, and ZK circuits.

## Changes

### fix(escrow-contract) — Issue #179
- Verified that `write_auto_pay` and `read_auto_pay` already use the same composite key `(commitment, rule_id)` consistently.
- Added `test_auto_pay_multiple_vaults_no_interference` to confirm rules registered on different vaults with the same global `rule_id` do not interfere with each other.

### feat(core-contract) — Issue #187
- Added `AlreadyInitialized = 9` to `CoreError`.
- Added `DataKey::Owner` to `storage.rs` with `set_owner`, `get_owner`, and `is_initialized` helpers.
- Added `initialize(env, owner: Address)` entry point that stores the owner in instance storage and panics with `AlreadyInitialized` on a second call.
- Added `get_contract_owner() -> Address` getter.
- Added tests: success, double-init panic, pre-init access panic.

### feat(core-contract) — Issue #193
- Added `DataKey::ShieldedAddress(BytesN<32>)` to `storage.rs` with `set_shielded_address`, `get_shielded_address`, and `has_shielded_address` helpers.
- Added `add_shielded_address(caller, username_hash, address_commitment)` — only the registered username owner may call this; stores the ZK commitment, never the raw address; emits `SHIELDED_ADD` event.
- Added `get_shielded_address(username_hash) -> Option<BytesN<32>>` getter.
- Added `is_shielded(username_hash) -> bool` helper.
- Added `shielded_add_event` to `events.rs`.
- Added tests: success, overwrite, non-owner rejection, unregistered username panic.

### fix(zk) — Issue #175
- Added `include "circomlib/circuits/comparators.circom"` to both `username_hash_impl.circom` and `username_hash.circom`.
- Added 32 `LessThan(8)` range-check components enforcing `username[i] < 128` for every input element, fixing Finding F-03.
- Added `zk/tests/test_username_range_check.js` with 5 tests: valid ASCII accepted, zero-bytes accepted, boundary value 127 accepted, value 128 rejected, value 255 rejected.

## Test results

```
cargo test — 107 passed, 0 failed
```

## Closes

Closes #179
Closes #187
Closes #193
Closes #175

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * One-time contract initialization with owner management and init event emission
  * Shielded address registration, ownership-checked writes, overwrite behavior, retrieval, and is-shielded checks
  * Username character validation enforced in zero-knowledge proofs (ASCII 0–127)

* **Bug Fixes**
  * Re-initialization is prevented and now errors on a second attempt

* **Tests**
  * Added tests for initialization/ownership, shielded addresses, multi-vault auto-pay isolation, and username range checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->