### PR TITLE
refactor(core-contract): replace bare panic calls with typed errors

### DIFF
--- a/gateway-contract/contracts/core_contract/src/errors.rs
+++ b/gateway-contract/contracts/core_contract/src/errors.rs
@@ -22,6 +22,8 @@ pub enum CoreError {
     SameOwner = 8,
     /// initialize() has already been called on this contract instance.
     AlreadyInitialized = 9,
+    /// Commitment is already registered via register().
+    AlreadyRegistered = 10,
 }
 
 #[contracterror]

--- a/gateway-contract/contracts/core_contract/src/registration.rs
+++ b/gateway-contract/contracts/core_contract/src/registration.rs
@@ -1,6 +1,7 @@
+use crate::errors::CoreError;
 use crate::events::REGISTER_EVENT;
 use crate::storage::{PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
-use soroban_sdk::{contracttype, Address, BytesN, Env};
+use soroban_sdk::{contracttype, panic_with_error, Address, BytesN, Env};
 
 // Storage Keys
 #[contracttype]
@@ -23,7 +24,7 @@ impl Registration {
         // Check if commitment already exists
         let key = DataKey::Commitment(commitment.clone());
         if env.storage().persistent().has(&key) {
-            panic!("Commitment already registered");
+            panic_with_error!(&env, CoreError::AlreadyRegistered);
         }
 
         // Store commitment -> address mapping

--- a/gateway-contract/contracts/core_contract/src/test.rs
+++ b/gateway-contract/contracts/core_contract/src/test.rs
@@ -47,7 +47,7 @@ fn test_register_success() {
 }
 
 #[test]
-#[should_panic(expected = "Commitment already registered")]
+#[should_panic(expected = "Error(Contract, #10)")]
 fn test_register_duplicate_panics() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

This PR replaces bare string `panic!()` usage in the core contract registration flow with typed contract errors, so failures are machine-readable and testable through Soroban client error paths.

## What Changed

- Added `AlreadyRegistered` to `CoreError` in `gateway-contract/contracts/core_contract/src/errors.rs`.
- Updated `Registration::register` in `gateway-contract/contracts/core_contract/src/registration.rs`:
  - Replaced `panic!("Commitment already registered")`
  - With `panic_with_error!(&env, CoreError::AlreadyRegistered)`
- Updated duplicate registration test in `gateway-contract/contracts/core_contract/src/test.rs`:
  - `test_register_duplicate_panics` now asserts typed contract panic output (`Error(Contract, #10)`).
- Audited contract source files for bare `panic!()` usage and removed remaining string panic from contract code.

## Why

Typed contract errors are required for reliable client handling and deterministic test assertions. String panics are not suitable for contract-level error APIs.

## How to Verify

From the repository root:

```bash
cd gateway-contract
cargo test -p core_contract
cargo test
```

Expected result:
- All affected `core_contract` tests pass.
- Workspace tests are green.
- No bare `panic!()` calls remain in `gateway-contract/contracts/*/src/*.rs` contract source.

## Footer

Closes https://github.com/Alien-Protocol/Alien-Gateway/issues/181
Closes #181 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for duplicate commitment registration. Users now receive standardized, structured error messages when attempting to register an already-registered commitment, providing clearer and more consistent feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->