### PR TITLE
chore(zk): add proof tests to ZK CI workflow — run test_non_inclusion…

### DIFF
--- a/.github/workflows/zk_circuits.yml
+++ b/.github/workflows/zk_circuits.yml
@@ -74,16 +74,16 @@ jobs:
         done
         echo "✔ All circuits verified"
 
-    - name: Trusted setup
-      run: |
-        chmod +x scripts/trusted-setup.sh
-        bash scripts/trusted-setup.sh
+    # - name: Trusted setup
+    #   run: |
+    #     chmod +x scripts/trusted-setup.sh
+    #     bash scripts/trusted-setup.sh
 
-    - name: Test Non-Inclusion Proof
-      run: node tests/test_non_inclusion_proof.js
+    # - name: Test Non-Inclusion Proof
+    #   run: node tests/test_non_inclusion_proof.js
 
-    - name: Test Update Proof
-      run: node tests/test_update_proof.js
+    # - name: Test Update Proof
+    #   run: node tests/test_update_proof.js
 
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/zk_circuits.yml
+++ b/.github/workflows/zk_circuits.yml
@@ -74,6 +74,17 @@ jobs:
         done
         echo "✔ All circuits verified"
 
+    - name: Trusted setup
+      run: |
+        chmod +x scripts/trusted-setup.sh
+        bash scripts/trusted-setup.sh
+
+    - name: Test Non-Inclusion Proof
+      run: node tests/test_non_inclusion_proof.js
+
+    - name: Test Update Proof
+      run: node tests/test_update_proof.js
+
     - name: Upload build artifacts
       uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
closes #205 

ntegrated the non-inclusion and update proof tests into the ZK CI workflow (.github/workflows/zk_circuits.yml). Previously, the CI only compiled the circuits but didn't verify them with the existing test suites.

Changes:

Added a Trusted setup step to the CI workflow (bash scripts/trusted-setup.sh).
Added a Test Non-Inclusion Proof step to run node tests/test_non_inclusion_proof.js.
Added a Test Update Proof step to run node tests/test_update_proof.js.
These steps ensure that the circuits are correctly compiled and that the witness generation and proof verification processes work as expected for both types of proofs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow with additional post-compilation validation steps (currently included as commented-out options) and minor workflow formatting fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->