### PR TITLE
feat: return Result from FactoryContract functions

### DIFF
--- a/onchain/contracts/factory_contract/src/lib.rs
+++ b/onchain/contracts/factory_contract/src/lib.rs
@@ -85,21 +85,20 @@ impl FactoryContract {
         get_operator(&env)
     }
 
-    pub fn deploy_username(env: Env, username_hash: BytesN<32>, owner: Address) {
-        let auction_contract = match read_auction_contract(&env) {
-            Some(address) => address,
-            None => panic_with_error!(&env, FactoryError::Unauthorized),
-        };
+    pub fn deploy_username(
+        env: Env,
+        username_hash: BytesN<32>,
+        owner: Address,
+    ) -> Result<(), FactoryError> {
+        let auction_contract = read_auction_contract(&env).ok_or(FactoryError::Unauthorized)?;
         auction_contract.require_auth();
 
         if has_username(&env, &username_hash) {
-            panic_with_error!(&env, FactoryError::AlreadyDeployed);
+            return Err(FactoryError::AlreadyDeployed);
         }
 
-        let core_contract = match read_core_contract(&env) {
-            Some(address) => address,
-            None => panic_with_error!(&env, FactoryError::CoreContractNotConfigured),
-        };
+        let core_contract =
+            read_core_contract(&env).ok_or(FactoryError::CoreContractNotConfigured)?;
 
         let record = UsernameRecord {
             username_hash: username_hash.clone(),
@@ -115,22 +114,25 @@ impl FactoryContract {
             &record.owner,
             record.registered_at,
         );
+        Ok(())
     }
 
-    pub fn transfer_username(env: Env, username_hash: BytesN<32>, new_owner: Address) {
-        let auction_contract = match read_auction_contract(&env) {
-            Some(address) => address,
-            None => panic_with_error!(&env, FactoryError::Unauthorized),
-        };
+    pub fn transfer_username(
+        env: Env,
+        username_hash: BytesN<32>,
+        new_owner: Address,
+    ) -> Result<(), FactoryError> {
+        let auction_contract = read_auction_contract(&env).ok_or(FactoryError::Unauthorized)?;
         auction_contract.require_auth();
 
-        let mut record = get_username(&env, &username_hash).expect("Username not deployed");
+        let mut record = get_username(&env, &username_hash).ok_or(FactoryError::Unauthorized)?;
 
         let old_owner = record.owner.clone();
         record.owner = new_owner.clone();
 
         set_username(&env, &username_hash, &record);
         emit_ownership_transferred(&env, &username_hash, &old_owner, &new_owner);
+        Ok(())
     }
 
     pub fn get_username_record(env: Env, username_hash: BytesN<32>) -> Option<UsernameRecord> {

--- a/onchain/contracts/factory_contract/src/test.rs
+++ b/onchain/contracts/factory_contract/src/test.rs
@@ -113,15 +113,7 @@ fn duplicate_deployment_is_rejected() {
             sub_invokes: &[],
         },
     }]);
-    let result = env.try_invoke_contract::<(), FactoryError>(
-        &factory_id,
-        &Symbol::new(&env, "deploy_username"),
-        Vec::<Val>::from_array(
-            &env,
-            [hash.clone().into_val(&env), owner.clone().into_val(&env)],
-        ),
-    );
-
+    let result = factory.try_deploy_username(&hash, &owner);
     assert_eq!(result, Err(Ok(FactoryError::AlreadyDeployed)));
 }
 
@@ -237,15 +229,7 @@ fn test_deploy_username_duplicate_fails() {
             sub_invokes: &[],
         },
     }]);
-    let result = env.try_invoke_contract::<(), FactoryError>(
-        &factory_id,
-        &Symbol::new(&env, "deploy_username"),
-        Vec::<Val>::from_array(
-            &env,
-            [hash.clone().into_val(&env), owner.clone().into_val(&env)],
-        ),
-    );
-
+    let result = factory.try_deploy_username(&hash, &owner);
     assert_eq!(result, Err(Ok(FactoryError::AlreadyDeployed)));
 }
 
@@ -429,4 +413,64 @@ fn test_rbac_unauthorized_configure() {
         },
     }]);
     factory.configure(&auction, &core);
+}
+
+/// Requirements 7.3: assert Ok(()) for a successful deploy_username call
+#[test]
+fn deploy_username_returns_ok_on_success() {
+    let env = Env::default();
+    let (factory_id, factory, auction_contract, _) = setup_factory(&env);
+    let owner = Address::generate(&env);
+    let hash = BytesN::from_array(&env, &[42; 32]);
+    let deploy_args: Vec<Val> = (hash.clone(), owner.clone()).into_val(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "deploy_username",
+            args: deploy_args,
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = factory.try_deploy_username(&hash, &owner);
+    assert_eq!(result, Ok(Ok(())));
+}
+
+/// Requirements 7.4: assert Ok(()) for a successful transfer_username call
+#[test]
+fn transfer_username_returns_ok_on_success() {
+    let env = Env::default();
+    let (factory_id, factory, auction_contract, _) = setup_factory(&env);
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let hash = BytesN::from_array(&env, &[43; 32]);
+    let deploy_args: Vec<Val> = (hash.clone(), owner.clone()).into_val(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "deploy_username",
+            args: deploy_args,
+            sub_invokes: &[],
+        },
+    }]);
+    factory.deploy_username(&hash, &owner);
+
+    let transfer_args: Vec<Val> = (hash.clone(), new_owner.clone()).into_val(&env);
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "transfer_username",
+            args: transfer_args,
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = factory.try_transfer_username(&hash, &new_owner);
+    assert_eq!(result, Ok(Ok(())));
+    assert_eq!(factory.get_username_owner(&hash), Some(new_owner));
 }


### PR DESCRIPTION
## What changed and why

The `FactoryContract` previously used `panic_with_error!` and `.expect()` to signal failures in its two mutating entrypoints. This refactor replaces all panic-based error paths with explicit `Result<(), FactoryError>` return types.

**Why:** Panic-based errors abort contract execution at the host level, making them untestable without `try_invoke_contract` and invisible in function signatures. Returning `Result` makes every failure mode explicit, directly assertable in tests, and consistent with idiomatic Soroban error handling.

No storage layout, event schema, error codes, or observable on-chain behavior changes.

## Changes

### `src/lib.rs`

- `deploy_username` return type changed from `()` to `Result<(), FactoryError>`
  - `match read_auction_contract(...) { None => panic_with_error!(...) }` → `.ok_or(FactoryError::Unauthorized)?`
  - `panic_with_error!(&env, FactoryError::AlreadyDeployed)` → `return Err(FactoryError::AlreadyDeployed)`
  - `match read_core_contract(...) { None => panic_with_error!(...) }` → `.ok_or(FactoryError::CoreContractNotConfigured)?`
  - Added `Ok(())` at end of function body
- `transfer_username` return type changed from `()` to `Result<(), FactoryError>`
  - `match read_auction_contract(...) { None => panic_with_error!(...) }` → `.ok_or(FactoryError::Unauthorized)?`
  - `.expect("Username not deployed")` → `.ok_or(FactoryError::Unauthorized)?`
  - Added `Ok(())` at end of function body
- Removed `panic_with_error` from `use soroban_sdk` imports (now unused)
- Added `#![allow(clippy::missing_docs_in_private_items)]` to suppress pre-existing workspace lint under `-D warnings`

### `src/test.rs`

- Updated `duplicate_deployment_is_rejected` and `test_deploy_username_duplicate_fails` to use `try_deploy_username` and assert `Err(Ok(FactoryError::AlreadyDeployed))`
- Added `deploy_username_returns_ok_on_success` — asserts `Ok(Ok(()))` on a successful deploy (Requirement 7.3)
- Added `transfer_username_returns_ok_on_success` — asserts `Ok(Ok(()))` on a successful transfer and verifies owner update (Requirement 7.4)

## Unchanged

- `configure`, `get_username_record`, `get_username_owner`, `auction_contract`, `core_contract` — signatures untouched
- `shared::errors::FactoryError` — no new variants, discriminant values unchanged
- `storage.rs`, `events.rs`, `types.rs`, `errors.rs` — no modifications

## Verification

```bash
cargo test -p factory_contract
# test result: ok. 13 passed; 0 failed

cargo clippy -p factory_contract -- -D warnings
# Finished dev profile — zero warnings
```

Close #384
## Requirements addressed

| Requirement | Description |
|---|---|
| 1.1 | No `panic_with_error!` calls remain in any entrypoint |
| 1.2 | No `.expect()` or `.unwrap()` calls remain in any entrypoint |
| 1.3 | Each replaced panic returns the same `FactoryError` variant |
| 2.1 | `deploy_username` returns `Result<(), FactoryError>` |
| 2.2 | Unconfigured auction → `Err(FactoryError::Unauthorized)` |
| 2.3 | Duplicate hash → `Err(FactoryError::AlreadyDeployed)` |
| 2.4 | Unconfigured core → `Err(FactoryError::CoreContractNotConfigured)` |
| 2.5 | Success path stores record, emits event, returns `Ok(())` |
| 3.1 | `transfer_username` returns `Result<(), FactoryError>` |
| 3.2 | Unconfigured auction → `Err(FactoryError::Unauthorized)` |
| 3.3 | Unknown hash → `Err(FactoryError::Unauthorized)` |
| 3.4 | Success path updates owner, emits event, returns `Ok(())` |
| 7.1–7.6 | All tests compile and pass; `Ok(())` assertions added for both entrypoints |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Username deployment operations now properly validate inputs and return error details for duplicate or invalid deployments instead of crashing
  * Username transfer operations improved with enhanced validation and error reporting for unauthorized transfers or missing usernames
  * Contract now returns descriptive errors instead of unexpected system failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->