### PR TITLE
test: add comprehensive coverage for transfer_username flow 

### DIFF
--- a/gateway-contract/contracts/factory_contract/src/errors.rs
+++ b/gateway-contract/contracts/factory_contract/src/errors.rs
@@ -7,4 +7,5 @@ pub enum FactoryError {
     Unauthorized = 1,
     AlreadyDeployed = 2,
     CoreContractNotConfigured = 3,
+    NotDeployed = 4,
 }

--- a/gateway-contract/contracts/factory_contract/src/events.rs
+++ b/gateway-contract/contracts/factory_contract/src/events.rs
@@ -1,6 +1,6 @@
 use soroban_sdk::{contractevent, Address, BytesN, Env};
 
-use crate::types::UsernameRecord;
+use crate::types::{UsernameRecord, UsernameTransferredPayload};
 
 #[contractevent(topics = ["USERNAME_DEPLOYED"], data_format = "single-value")]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -17,6 +17,30 @@ pub fn emit_username_deployed(env: &Env, record: &UsernameRecord) {
         username_hash: record.username_hash.clone(),
         owner: record.owner.clone(),
         record: record.clone(),
+    }
+    .publish(env);
+}
+
+#[contractevent(topics = ["USERNAME_TRANSFERRED"], data_format = "single-value")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UsernameTransferredEvent {
+    #[topic]
+    pub username_hash: BytesN<32>,
+    pub payload: UsernameTransferredPayload,
+}
+
+pub fn emit_username_transferred(
+    env: &Env,
+    username_hash: BytesN<32>,
+    old_owner: Address,
+    new_owner: Address,
+) {
+    UsernameTransferredEvent {
+        username_hash,
+        payload: UsernameTransferredPayload {
+            old_owner,
+            new_owner,
+        },
     }
     .publish(env);
 }

--- a/gateway-contract/contracts/factory_contract/src/lib.rs
+++ b/gateway-contract/contracts/factory_contract/src/lib.rs
@@ -11,7 +11,7 @@ mod test;
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, BytesN, Env};
 
 use crate::errors::FactoryError;
-use crate::events::emit_username_deployed;
+use crate::events::{emit_username_deployed, emit_username_transferred};
 use crate::storage::{
     get_auction_contract, get_core_contract, get_username_record, set_auction_contract,
     set_core_contract, set_username_record,
@@ -53,6 +53,25 @@ impl FactoryContract {
 
         set_username_record(&env, &record);
         emit_username_deployed(&env, &record);
+    }
+
+    pub fn transfer_username(env: Env, username_hash: BytesN<32>, new_owner: Address) {
+        let auction_contract = match get_auction_contract(&env) {
+            Some(address) => address,
+            None => panic_with_error!(&env, FactoryError::Unauthorized),
+        };
+        auction_contract.require_auth();
+
+        let mut record = match get_username_record(&env, &username_hash) {
+            Some(record) => record,
+            None => panic_with_error!(&env, FactoryError::NotDeployed),
+        };
+
+        let old_owner = record.owner.clone();
+        record.owner = new_owner.clone();
+
+        set_username_record(&env, &record);
+        emit_username_transferred(&env, username_hash, old_owner, new_owner);
     }
 
     pub fn get_username_record(env: Env, username_hash: BytesN<32>) -> Option<UsernameRecord> {

--- a/gateway-contract/contracts/factory_contract/src/test.rs
+++ b/gateway-contract/contracts/factory_contract/src/test.rs
@@ -1,4 +1,4 @@
-#![cfg(test)]
+
 
 use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
 use soroban_sdk::{contract, contractimpl, IntoVal, Symbol, TryFromVal, Val, Vec};
@@ -137,4 +137,108 @@ fn non_registered_auction_auth_is_rejected() {
 
     assert!(result.is_err());
     assert_ne!(wrong_caller, auction_contract);
+}
+
+#[test]
+fn transfer_username_success_and_emits_event() {
+    let env = Env::default();
+    let (factory_id, factory, auction_contract, _) = setup_factory(&env);
+    let owner = Address::generate(&env);
+    let new_owner = Address::generate(&env);
+    let hash = username_hash(&env);
+
+    let deploy_args: Vec<Val> = (hash.clone(), owner.clone()).into_val(&env);
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "deploy_username",
+            args: deploy_args,
+            sub_invokes: &[],
+        },
+    }]);
+    factory.deploy_username(&hash, &owner);
+
+    let transfer_args: Vec<Val> = (hash.clone(), new_owner.clone()).into_val(&env);
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "transfer_username",
+            args: transfer_args,
+            sub_invokes: &[],
+        },
+    }]);
+    factory.transfer_username(&hash, &new_owner);
+
+    let events = env.events().all();
+
+    let record = factory.get_username_record(&hash).unwrap();
+    assert_eq!(record.owner, new_owner);
+
+    assert_eq!(events.len(), 1);
+
+    let (event_contract, topics, data) = events.get(0).unwrap();
+    assert_eq!(event_contract, factory_id);
+    assert_eq!(topics.len(), 2);
+
+    let event_name = Symbol::try_from_val(&env, &topics.get(0).unwrap()).unwrap();
+    let event_hash = BytesN::<32>::try_from_val(&env, &topics.get(1).unwrap()).unwrap();
+    
+    let event_payload = crate::types::UsernameTransferredPayload::try_from_val(&env, &data).unwrap();
+
+    assert_eq!(event_name, Symbol::new(&env, "USERNAME_TRANSFERRED"));
+    assert_eq!(event_hash, hash);
+    assert_eq!(event_payload.old_owner, owner);
+    assert_eq!(event_payload.new_owner, new_owner);
+}
+
+#[test]
+fn transfer_username_fails_when_auction_not_configured() {
+    let env = Env::default();
+    let factory_id = env.register(crate::FactoryContract, ());
+
+    let hash = username_hash(&env);
+    let new_owner = Address::generate(&env);
+
+    let result = env.try_invoke_contract::<(), FactoryError>(
+        &factory_id,
+        &Symbol::new(&env, "transfer_username"),
+        Vec::<Val>::from_array(
+            &env,
+            [hash.into_val(&env), new_owner.into_val(&env)],
+        ),
+    );
+
+    assert_eq!(result, Err(Ok(FactoryError::Unauthorized)));
+}
+
+#[test]
+fn transfer_username_fails_when_not_deployed() {
+    let env = Env::default();
+    let (factory_id, _, auction_contract, _) = setup_factory(&env);
+    let hash = username_hash(&env);
+    let new_owner = Address::generate(&env);
+
+    let transfer_args: Vec<Val> = (hash.clone(), new_owner.clone()).into_val(&env);
+    env.mock_auths(&[MockAuth {
+        address: &auction_contract,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "transfer_username",
+            args: transfer_args,
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = env.try_invoke_contract::<(), FactoryError>(
+        &factory_id,
+        &Symbol::new(&env, "transfer_username"),
+        Vec::<Val>::from_array(
+            &env,
+            [hash.into_val(&env), new_owner.into_val(&env)],
+        ),
+    );
+
+    assert_eq!(result, Err(Ok(FactoryError::NotDeployed)));
 }

--- a/gateway-contract/contracts/factory_contract/src/types.rs
+++ b/gateway-contract/contracts/factory_contract/src/types.rs
@@ -8,3 +8,10 @@ pub struct UsernameRecord {
     pub registered_at: u64,
     pub core_contract: Address,
 }
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UsernameTransferredPayload {
+    pub old_owner: Address,
+    pub new_owner: Address,
+}


### PR DESCRIPTION
Closes #393
## Description


This PR implements robust, comprehensive testing for the FactoryContract::transfer_username flow and brings its implementation to a production-grade standard. It ensures the auction mechanism correctly transfers digital ownership rights with exactly O(1) time and space complexities. Storage overwrite operations have been safely structured around cleanly-architected authorization verifications and modularized event payloads.

Functions Supported
transfer_username (In Scope)
Changes Made
Errors: Added a new enumeration NotDeployed = 4 to securely restrict state-change workflows against undefined registry strings.
Types: Introduced a reusable, struct-packaged UsernameTransferredPayload ensuring pristine decoding functionality in standard architecture schemas.
Events: Added UsernameTransferredEvent and emit_username_transferred adhering identically to the module's established standards without compromising tuple indexing boundaries.
Storage/Modifiers: Completed successful routing in the overarching transfer_username caller—asserting auction contract authorization statically before replacing ownership parameters and executing telemetry storage.
Coverage: Addended three complete testing routines into test.rs:
transfer_username_success_and_emits_event: Verifies correct storage mutation and validates event emissions properties mapping.
transfer_username_fails_when_auction_not_configured: Gracefully bubbles out an expected FactoryError::Unauthorized.
transfer_username_fails_when_not_deployed: Confirms standard verification mechanisms correctly abort under FactoryError::NotDeployed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Username ownership transfer capability is now available
  * Transfer events emit with previous and new owner information

* **Tests**
  * Comprehensive test coverage added for username transfer operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->