### PR TITLE
refactor: extract shared authorization and storage helpers across onc…

### DIFF
--- a/onchain/contracts/auction_contract/src/lib.rs
+++ b/onchain/contracts/auction_contract/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+use shared::auth as shared_auth;
 use soroban_sdk::{contract, contractimpl, Address, BytesN, Env};
 
 pub mod errors;
@@ -76,13 +77,16 @@ impl AuctionContract {
     }
 
     pub fn refund_bid(env: Env, id: u32, bidder: Address) {
-        bidder.require_auth();
+        shared_auth::require_address_auth(&bidder);
 
         // Ensure auction is closed
         let status = storage::auction_get_status(&env, id);
-        if status != types::AuctionStatus::Closed {
-            soroban_sdk::panic_with_error!(&env, errors::AuctionError::NotClosed);
-        }
+        require_status(
+            &env,
+            status,
+            types::AuctionStatus::Closed,
+            errors::AuctionError::NotClosed,
+        );
 
         // Winner cannot claim a refund via this path
         let highest_bidder = storage::auction_get_highest_bidder(&env, id);

--- a/onchain/contracts/auction_contract/src/storage.rs
+++ b/onchain/contracts/auction_contract/src/storage.rs
@@ -1,10 +1,13 @@
 use crate::types::{AuctionState, AuctionStatus, Bid, InstanceKey};
+use shared::storage as shared_storage;
 use soroban_sdk::{contracttype, Address, BytesN, Env, Vec};
 
 /// TTL constants for persistent storage entries.
 /// PERSISTENT_BUMP_AMOUNT: 30 days × 24h × 3600s / 5s per ledger = 518_400 ledgers
+#[allow(dead_code)]
 pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400; // 30 * 24 * 3600 / 5
 /// PERSISTENT_LIFETIME_THRESHOLD: 7 days × 24h × 3600s / 5s per ledger = 120_960 ledgers
+#[allow(dead_code)]
 pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960; // 7 * 24 * 3600 / 5
 
 #[contracttype]
@@ -15,58 +18,43 @@ pub enum DataKey {
 }
 
 pub fn get_status(env: &Env) -> AuctionStatus {
-    env.storage()
-        .instance()
-        .get(&InstanceKey::Status)
-        .unwrap_or(AuctionStatus::Open)
+    shared_storage::get_instance(env, &InstanceKey::Status).unwrap_or(AuctionStatus::Open)
 }
 
 pub fn set_status(env: &Env, status: AuctionStatus) {
-    env.storage().instance().set(&InstanceKey::Status, &status);
+    shared_storage::set_instance(env, &InstanceKey::Status, &status);
 }
 
 pub fn get_highest_bidder(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&InstanceKey::HighestBidder)
+    shared_storage::get_instance(env, &InstanceKey::HighestBidder)
 }
 
 pub fn set_highest_bidder(env: &Env, bidder: &Address) {
-    env.storage()
-        .instance()
-        .set(&InstanceKey::HighestBidder, bidder);
+    shared_storage::set_instance(env, &InstanceKey::HighestBidder, bidder);
 }
 
 pub fn get_factory_contract(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&InstanceKey::FactoryContract)
+    shared_storage::get_instance(env, &InstanceKey::FactoryContract)
 }
 
 pub fn set_factory_contract(env: &Env, factory: &Address) {
-    env.storage()
-        .instance()
-        .set(&InstanceKey::FactoryContract, factory);
+    shared_storage::set_instance(env, &InstanceKey::FactoryContract, factory);
 }
 
 pub fn get_end_time(env: &Env) -> u64 {
-    env.storage()
-        .instance()
-        .get(&InstanceKey::EndTime)
-        .unwrap_or(0)
+    shared_storage::get_instance(env, &InstanceKey::EndTime).unwrap_or(0)
 }
 
 pub fn set_end_time(env: &Env, end_time: u64) {
-    env.storage()
-        .instance()
-        .set(&InstanceKey::EndTime, &end_time);
+    shared_storage::set_instance(env, &InstanceKey::EndTime, &end_time);
 }
 
 pub fn get_highest_bid(env: &Env) -> u128 {
-    env.storage()
-        .instance()
-        .get(&InstanceKey::HighestBid)
-        .unwrap_or(0)
+    shared_storage::get_instance(env, &InstanceKey::HighestBid).unwrap_or(0)
 }
 
 pub fn set_highest_bid(env: &Env, bid: u128) {
-    env.storage().instance().set(&InstanceKey::HighestBid, &bid);
+    shared_storage::set_instance(env, &InstanceKey::HighestBid, &bid);
 }
 
 // --- id-scoped auction storage ---
@@ -85,12 +73,7 @@ pub fn auction_get_status(env: &Env, id: u32) -> crate::types::AuctionStatus {
 
 pub fn auction_set_status(env: &Env, id: u32, status: crate::types::AuctionStatus) {
     let key = AuctionKey::Status(id);
-    env.storage().persistent().set(&key, &status);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, &status);
 }
 
 pub fn auction_get_seller(env: &Env, id: u32) -> Address {
@@ -102,12 +85,7 @@ pub fn auction_get_seller(env: &Env, id: u32) -> Address {
 
 pub fn auction_set_seller(env: &Env, id: u32, seller: &Address) {
     let key = AuctionKey::Seller(id);
-    env.storage().persistent().set(&key, seller);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, seller);
 }
 
 pub fn auction_get_asset(env: &Env, id: u32) -> Address {
@@ -119,12 +97,7 @@ pub fn auction_get_asset(env: &Env, id: u32) -> Address {
 
 pub fn auction_set_asset(env: &Env, id: u32, asset: &Address) {
     let key = AuctionKey::Asset(id);
-    env.storage().persistent().set(&key, asset);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, asset);
 }
 
 pub fn auction_get_min_bid(env: &Env, id: u32) -> i128 {
@@ -136,12 +109,7 @@ pub fn auction_get_min_bid(env: &Env, id: u32) -> i128 {
 
 pub fn auction_set_min_bid(env: &Env, id: u32, min_bid: i128) {
     let key = AuctionKey::MinBid(id);
-    env.storage().persistent().set(&key, &min_bid);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, &min_bid);
 }
 
 pub fn auction_get_end_time(env: &Env, id: u32) -> u64 {
@@ -153,12 +121,7 @@ pub fn auction_get_end_time(env: &Env, id: u32) -> u64 {
 
 pub fn auction_set_end_time(env: &Env, id: u32, end_time: u64) {
     let key = AuctionKey::EndTime(id);
-    env.storage().persistent().set(&key, &end_time);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, &end_time);
 }
 
 pub fn auction_get_highest_bidder(env: &Env, id: u32) -> Option<Address> {
@@ -169,12 +132,7 @@ pub fn auction_get_highest_bidder(env: &Env, id: u32) -> Option<Address> {
 
 pub fn auction_set_highest_bidder(env: &Env, id: u32, bidder: &Address) {
     let key = AuctionKey::HighestBidder(id);
-    env.storage().persistent().set(&key, bidder);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, bidder);
 }
 
 pub fn auction_get_highest_bid(env: &Env, id: u32) -> i128 {
@@ -186,12 +144,7 @@ pub fn auction_get_highest_bid(env: &Env, id: u32) -> i128 {
 
 pub fn auction_set_highest_bid(env: &Env, id: u32, bid: i128) {
     let key = AuctionKey::HighestBid(id);
-    env.storage().persistent().set(&key, &bid);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, &bid);
 }
 
 pub fn auction_is_claimed(env: &Env, id: u32) -> bool {
@@ -203,12 +156,7 @@ pub fn auction_is_claimed(env: &Env, id: u32) -> bool {
 
 pub fn auction_set_claimed(env: &Env, id: u32) {
     let key = AuctionKey::Claimed(id);
-    env.storage().persistent().set(&key, &true);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, &true);
 }
 
 pub fn auction_get_username_hash(env: &Env, id: u32) -> BytesN<32> {
@@ -220,12 +168,7 @@ pub fn auction_get_username_hash(env: &Env, id: u32) -> BytesN<32> {
 
 pub fn auction_set_username_hash(env: &Env, id: u32, username_hash: &BytesN<32>) {
     let key = AuctionKey::UsernameHash(id);
-    env.storage().persistent().set(&key, username_hash);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, username_hash);
 }
 
 pub fn auction_get_outbid_amount(env: &Env, id: u32, bidder: &Address) -> i128 {
@@ -237,12 +180,7 @@ pub fn auction_get_outbid_amount(env: &Env, id: u32, bidder: &Address) -> i128 {
 
 pub fn auction_set_outbid_amount(env: &Env, id: u32, bidder: &Address, amount: i128) {
     let key = AuctionKey::OutbidAmount(id, bidder.clone());
-    env.storage().persistent().set(&key, &amount);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, &amount);
 }
 
 pub fn auction_is_bid_refunded(env: &Env, id: u32, bidder: &Address) -> bool {
@@ -254,30 +192,18 @@ pub fn auction_is_bid_refunded(env: &Env, id: u32, bidder: &Address) -> bool {
 
 pub fn auction_set_bid_refunded(env: &Env, id: u32, bidder: &Address) {
     let key = AuctionKey::BidRefunded(id, bidder.clone());
-    env.storage().persistent().set(&key, &true);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, &true);
 }
 
 // --- persistent storage helpers for AuctionState and Bid ---
 
 pub fn get_auction(env: &Env, hash: &BytesN<32>) -> Option<AuctionState> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Auction(hash.clone()))
+    shared_storage::get_persistent(env, &DataKey::Auction(hash.clone()))
 }
 
 pub fn set_auction(env: &Env, hash: &BytesN<32>, state: &AuctionState) {
     let key = DataKey::Auction(hash.clone());
-    env.storage().persistent().set(&key, state);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, state);
 }
 
 pub fn has_auction(env: &Env, hash: &BytesN<32>) -> bool {
@@ -287,19 +213,12 @@ pub fn has_auction(env: &Env, hash: &BytesN<32>) -> bool {
 }
 
 pub fn get_bid(env: &Env, hash: &BytesN<32>, bidder: &Address) -> Option<Bid> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::Bid(hash.clone(), bidder.clone()))
+    shared_storage::get_persistent(env, &DataKey::Bid(hash.clone(), bidder.clone()))
 }
 
 pub fn set_bid(env: &Env, hash: &BytesN<32>, bidder: &Address, bid: &Bid) {
     let key = DataKey::Bid(hash.clone(), bidder.clone());
-    env.storage().persistent().set(&key, bid);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, bid);
 }
 
 pub fn get_all_bidders(env: &Env, hash: &BytesN<32>) -> Vec<Address> {
@@ -314,11 +233,6 @@ pub fn add_bidder(env: &Env, hash: &BytesN<32>, bidder: Address) {
     if !bidders.contains(&bidder) {
         bidders.push_back(bidder);
         let key = DataKey::AllBidders(hash.clone());
-        env.storage().persistent().set(&key, &bidders);
-        env.storage().persistent().extend_ttl(
-            &key,
-            PERSISTENT_LIFETIME_THRESHOLD,
-            PERSISTENT_BUMP_AMOUNT,
-        );
+        shared_storage::set_persistent(env, &key, &bidders);
     }
 }

--- a/onchain/contracts/core_contract/src/address_manager.rs
+++ b/onchain/contracts/core_contract/src/address_manager.rs
@@ -1,9 +1,10 @@
+use shared::{auth as shared_auth, storage as shared_storage};
 use soroban_sdk::{contracttype, panic_with_error, Address, Bytes, BytesN, Env, Vec};
 
 use crate::errors::{ChainAddressError, CoreError};
 use crate::events::{shielded_add_event, stellar_rem_event, ADDR_ADD, CHAIN_ADD, CHAIN_REM};
 use crate::registration::{DataKey as CommitmentKey, Registration};
-use crate::storage::{self, PERSISTENT_BUMP_AMOUNT, PERSISTENT_LIFETIME_THRESHOLD};
+use crate::storage;
 use crate::types::ChainType;
 
 #[contracttype]
@@ -41,30 +42,20 @@ impl AddressManager {
         chain: ChainType,
         address: Bytes,
     ) {
-        caller.require_auth();
-
         let owner_key = CommitmentKey::Commitment(username_hash.clone());
-        let owner: Address = env
-            .storage()
-            .persistent()
-            .get(&owner_key)
-            .unwrap_or_else(|| panic_with_error!(&env, ChainAddressError::NotRegistered));
-
-        if owner != caller {
-            panic_with_error!(&env, ChainAddressError::Unauthorized);
-        }
+        let owner: Address = shared_auth::unwrap_or_panic(
+            &env,
+            shared_storage::get_persistent(&env, &owner_key),
+            ChainAddressError::NotRegistered,
+        );
+        shared_auth::require_matching_auth(&env, &caller, &owner, ChainAddressError::Unauthorized);
 
         if !Self::validate_address(&chain, &address) {
             panic_with_error!(&env, ChainAddressError::InvalidAddress);
         }
 
         let key = ChainAddrKey::ChainAddress(username_hash.clone(), chain.clone());
-        env.storage().persistent().set(&key, &address);
-        env.storage().persistent().extend_ttl(
-            &key,
-            PERSISTENT_LIFETIME_THRESHOLD,
-            PERSISTENT_BUMP_AMOUNT,
-        );
+        shared_storage::set_persistent(&env, &key, &address);
 
         #[allow(deprecated)]
         env.events()
@@ -90,7 +81,7 @@ impl AddressManager {
         chain: ChainType,
     ) -> Option<Bytes> {
         let key = ChainAddrKey::ChainAddress(username_hash, chain);
-        env.storage().persistent().get(&key)
+        shared_storage::get_persistent(&env, &key)
     }
 
     /// Removes a blockchain address for a commitment on a specified chain.
@@ -116,18 +107,13 @@ impl AddressManager {
         username_hash: BytesN<32>,
         chain: ChainType,
     ) {
-        caller.require_auth();
-
         let owner_key = CommitmentKey::Commitment(username_hash.clone());
-        let owner: Address = env
-            .storage()
-            .persistent()
-            .get(&owner_key)
-            .unwrap_or_else(|| panic_with_error!(&env, ChainAddressError::NotRegistered));
-
-        if owner != caller {
-            panic_with_error!(&env, ChainAddressError::Unauthorized);
-        }
+        let owner: Address = shared_auth::unwrap_or_panic(
+            &env,
+            shared_storage::get_persistent(&env, &owner_key),
+            ChainAddressError::NotRegistered,
+        );
+        shared_auth::require_matching_auth(&env, &caller, &owner, ChainAddressError::Unauthorized);
 
         let key = ChainAddrKey::ChainAddress(username_hash.clone(), chain.clone());
         env.storage().persistent().remove(&key);
@@ -159,30 +145,21 @@ impl AddressManager {
         username_hash: BytesN<32>,
         stellar_address: Address,
     ) {
-        caller.require_auth();
+        let owner = shared_auth::unwrap_or_panic(
+            &env,
+            Registration::get_owner(env.clone(), username_hash.clone()),
+            CoreError::NotFound,
+        );
+        shared_auth::require_matching_auth(&env, &caller, &owner, CoreError::NotFound);
 
-        let owner = Registration::get_owner(env.clone(), username_hash.clone())
-            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
-
-        if owner != caller {
-            panic_with_error!(&env, CoreError::NotFound);
-        }
-
-        let mut linked_addresses: Vec<Address> = env
-            .storage()
-            .persistent()
-            .get(&storage::DataKey::StellarAddresses(username_hash.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
+        let addresses_key = storage::DataKey::StellarAddresses(username_hash.clone());
+        let mut linked_addresses: Vec<Address> =
+            shared_storage::get_persistent(&env, &addresses_key).unwrap_or_else(|| Vec::new(&env));
         linked_addresses.push_back(stellar_address.clone());
-        env.storage().persistent().set(
-            &storage::DataKey::StellarAddresses(username_hash.clone()),
-            &linked_addresses,
-        );
+        shared_storage::set_persistent(&env, &addresses_key, &linked_addresses);
 
-        env.storage().persistent().set(
-            &storage::DataKey::StellarAddress(username_hash),
-            &stellar_address,
-        );
+        let primary_key = storage::DataKey::StellarAddress(username_hash);
+        shared_storage::set_persistent(&env, &primary_key, &stellar_address);
 
         #[allow(deprecated)]
         env.events().publish((ADDR_ADD,), stellar_address.clone());
@@ -213,21 +190,17 @@ impl AddressManager {
         username_hash: BytesN<32>,
         stellar_address: Address,
     ) {
-        caller.require_auth();
-
-        let owner = Registration::get_owner(env.clone(), username_hash.clone())
-            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
-
-        if owner != caller {
-            panic_with_error!(&env, CoreError::Unauthorized);
-        }
+        let owner = shared_auth::unwrap_or_panic(
+            &env,
+            Registration::get_owner(env.clone(), username_hash.clone()),
+            CoreError::NotFound,
+        );
+        shared_auth::require_matching_auth(&env, &caller, &owner, CoreError::Unauthorized);
 
         // Rebuild the history list without the removed address.
-        let existing: Vec<Address> = env
-            .storage()
-            .persistent()
-            .get(&storage::DataKey::StellarAddresses(username_hash.clone()))
-            .unwrap_or_else(|| Vec::new(&env));
+        let addresses_key = storage::DataKey::StellarAddresses(username_hash.clone());
+        let existing: Vec<Address> =
+            shared_storage::get_persistent(&env, &addresses_key).unwrap_or_else(|| Vec::new(&env));
 
         let mut updated: Vec<Address> = Vec::new(&env);
         for addr in existing.iter() {
@@ -235,31 +208,21 @@ impl AddressManager {
                 updated.push_back(addr);
             }
         }
-        env.storage().persistent().set(
-            &storage::DataKey::StellarAddresses(username_hash.clone()),
-            &updated,
-        );
+        shared_storage::set_persistent(&env, &addresses_key, &updated);
 
         // If the removed address was the current primary, update or clear it.
-        let primary: Option<Address> = env
-            .storage()
-            .persistent()
-            .get(&storage::DataKey::StellarAddress(username_hash.clone()));
+        let primary_key = storage::DataKey::StellarAddress(username_hash.clone());
+        let primary: Option<Address> = shared_storage::get_persistent(&env, &primary_key);
 
         if let Some(p) = primary {
             if p == stellar_address {
                 if updated.is_empty() {
-                    env.storage()
-                        .persistent()
-                        .remove(&storage::DataKey::StellarAddress(username_hash.clone()));
+                    env.storage().persistent().remove(&primary_key);
                 } else {
                     let last = updated
                         .get(updated.len() - 1)
                         .expect("updated stellar address list should be non-empty");
-                    env.storage().persistent().set(
-                        &storage::DataKey::StellarAddress(username_hash.clone()),
-                        &last,
-                    );
+                    shared_storage::set_persistent(&env, &primary_key, &last);
                 }
             }
         }
@@ -274,12 +237,11 @@ impl AddressManager {
             panic_with_error!(&env, CoreError::NotFound);
         }
 
-        env.storage()
-            .persistent()
-            .get::<storage::DataKey, Vec<Address>>(&storage::DataKey::StellarAddresses(
-                username_hash,
-            ))
-            .unwrap_or_else(|| Vec::new(&env))
+        shared_storage::get_persistent::<storage::DataKey, Vec<Address>>(
+            &env,
+            &storage::DataKey::StellarAddresses(username_hash),
+        )
+        .unwrap_or_else(|| Vec::new(&env))
     }
 
     /// Resolves a commitment to its linked Stellar address.
@@ -302,10 +264,11 @@ impl AddressManager {
             panic_with_error!(&env, CoreError::NotFound);
         }
 
-        env.storage()
-            .persistent()
-            .get::<storage::DataKey, Address>(&storage::DataKey::StellarAddress(username_hash))
-            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NoAddressLinked))
+        shared_auth::unwrap_or_panic(
+            &env,
+            shared_storage::get_persistent(&env, &storage::DataKey::StellarAddress(username_hash)),
+            CoreError::NoAddressLinked,
+        )
     }
 
     /// Adds a shielded (privacy-preserving) address commitment for a commitment.
@@ -331,12 +294,12 @@ impl AddressManager {
         username_hash: BytesN<32>,
         address_commitment: BytesN<32>,
     ) {
-        caller.require_auth();
-        let owner = Registration::get_owner(env.clone(), username_hash.clone())
-            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
-        if owner != caller {
-            panic_with_error!(&env, CoreError::Unauthorized);
-        }
+        let owner = shared_auth::unwrap_or_panic(
+            &env,
+            Registration::get_owner(env.clone(), username_hash.clone()),
+            CoreError::NotFound,
+        );
+        shared_auth::require_matching_auth(&env, &caller, &owner, CoreError::Unauthorized);
         storage::set_shielded_address(&env, &username_hash, &address_commitment);
         #[allow(deprecated)]
         env.events().publish(

--- a/onchain/contracts/core_contract/src/admin.rs
+++ b/onchain/contracts/core_contract/src/admin.rs
@@ -1,3 +1,4 @@
+use shared::auth as shared_auth;
 use soroban_sdk::{panic_with_error, Address, BytesN, Env};
 
 use crate::errors::CoreError;
@@ -22,7 +23,7 @@ impl Admin {
     /// ### Events
     /// - Emits `INIT_EVENT` with the owner address.
     pub fn initialize(env: Env, owner: Address) {
-        owner.require_auth();
+        shared_auth::require_address_auth(&owner);
         if storage::is_initialized(&env) {
             panic_with_error!(&env, CoreError::AlreadyInitialized);
         }
@@ -39,7 +40,7 @@ impl Admin {
     /// ### Errors
     /// - `NotFound`: If the contract has not been initialized.
     pub fn get_contract_owner(env: Env) -> Address {
-        storage::get_owner(&env).unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound))
+        shared_auth::unwrap_or_panic(&env, storage::get_owner(&env), CoreError::NotFound)
     }
 
     /// Retrieves the current Sparse Merkle Tree (SMT) root hash.
@@ -52,8 +53,11 @@ impl Admin {
     /// ### Errors
     /// - `RootNotSet`: If the SMT root has not yet been set.
     pub fn get_smt_root(env: Env) -> BytesN<32> {
-        smt_root::SmtRoot::get_root(env.clone())
-            .unwrap_or_else(|| panic_with_error!(&env, CoreError::RootNotSet))
+        shared_auth::unwrap_or_panic(
+            &env,
+            smt_root::SmtRoot::get_root(env.clone()),
+            CoreError::RootNotSet,
+        )
     }
 
     /// Updates the SMT root as an authenticated public entry point.
@@ -73,9 +77,9 @@ impl Admin {
     /// ### Events
     /// - Emits `ROOT_UPDATED` event with (old_root, new_root).
     pub fn update_smt_root(env: Env, new_root: BytesN<32>) {
-        let owner = storage::get_owner(&env)
-            .unwrap_or_else(|| panic_with_error!(&env, CoreError::NotFound));
-        owner.require_auth();
+        let owner =
+            shared_auth::unwrap_or_panic(&env, storage::get_owner(&env), CoreError::NotFound);
+        shared_auth::require_address_auth(&owner);
 
         if let Some(current) = env
             .storage()

--- a/onchain/contracts/core_contract/src/storage.rs
+++ b/onchain/contracts/core_contract/src/storage.rs
@@ -1,3 +1,4 @@
+use shared::storage as shared_storage;
 use soroban_sdk::{contracttype, Address, BytesN, Env};
 
 use crate::types::PrivacyMode;
@@ -32,12 +33,7 @@ pub enum DataKey {
 
 pub fn set_privacy_mode(env: &Env, username_hash: &BytesN<32>, mode: &PrivacyMode) {
     let key = DataKey::PrivacyMode(username_hash.clone());
-    env.storage().persistent().set(&key, mode);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, mode);
 }
 
 pub fn get_privacy_mode(env: &Env, username_hash: &BytesN<32>) -> PrivacyMode {
@@ -48,11 +44,11 @@ pub fn get_privacy_mode(env: &Env, username_hash: &BytesN<32>) -> PrivacyMode {
 }
 
 pub fn set_owner(env: &Env, owner: &Address) {
-    env.storage().instance().set(&DataKey::Owner, owner);
+    shared_storage::set_instance(env, &DataKey::Owner, owner);
 }
 
 pub fn get_owner(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&DataKey::Owner)
+    shared_storage::get_instance(env, &DataKey::Owner)
 }
 
 pub fn is_initialized(env: &Env) -> bool {
@@ -61,18 +57,11 @@ pub fn is_initialized(env: &Env) -> bool {
 
 pub fn set_shielded_address(env: &Env, username_hash: &BytesN<32>, commitment: &BytesN<32>) {
     let key = DataKey::ShieldedAddress(username_hash.clone());
-    env.storage().persistent().set(&key, commitment);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, commitment);
 }
 
 pub fn get_shielded_address(env: &Env, username_hash: &BytesN<32>) -> Option<BytesN<32>> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::ShieldedAddress(username_hash.clone()))
+    shared_storage::get_persistent(env, &DataKey::ShieldedAddress(username_hash.clone()))
 }
 
 pub fn has_shielded_address(env: &Env, username_hash: &BytesN<32>) -> bool {
@@ -83,16 +72,9 @@ pub fn has_shielded_address(env: &Env, username_hash: &BytesN<32>) -> bool {
 
 pub fn set_created_at(env: &Env, username_hash: &BytesN<32>, timestamp: u64) {
     let key = DataKey::CreatedAt(username_hash.clone());
-    env.storage().persistent().set(&key, &timestamp);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, &timestamp);
 }
 
 pub fn get_created_at(env: &Env, username_hash: &BytesN<32>) -> Option<u64> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::CreatedAt(username_hash.clone()))
+    shared_storage::get_persistent(env, &DataKey::CreatedAt(username_hash.clone()))
 }

--- a/onchain/contracts/escrow_contract/src/lib.rs
+++ b/onchain/contracts/escrow_contract/src/lib.rs
@@ -19,6 +19,7 @@ use crate::storage::{
     write_vault_state,
 };
 use crate::types::{AutoPay, DataKey, ScheduledPayment, VaultConfig, VaultState};
+use shared::auth as shared_auth;
 use soroban_sdk::{
     contract, contractimpl, panic_with_error, token, vec, Address, BytesN, Env, IntoVal, Symbol,
 };
@@ -37,7 +38,7 @@ impl EscrowContract {
     /// ### Errors
     /// - `AlreadyInitialized`: If the Registration contract address is already set.
     pub fn initialize(env: Env, admin: Address, registration_contract: Address) {
-        admin.require_auth();
+        shared_auth::require_address_auth(&admin);
         if read_registration_contract(&env).is_some() {
             panic_with_error!(&env, EscrowError::AlreadyInitialized);
         }
@@ -58,8 +59,11 @@ impl EscrowContract {
     /// - `VaultAlreadyExists`: If a vault already exists for this commitment.
     pub fn create_vault(env: Env, commitment: BytesN<32>, token: Address) {
         // 1. Load Registration contract address (must be initialized first).
-        let registration = read_registration_contract(&env)
-            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::CommitmentNotRegistered));
+        let registration = shared_auth::unwrap_or_panic(
+            &env,
+            read_registration_contract(&env),
+            EscrowError::CommitmentNotRegistered,
+        );
 
         // 2. Cross-contract call: resolve owner from Registration contract.
         let owner: Option<Address> = env.invoke_contract(
@@ -67,11 +71,10 @@ impl EscrowContract {
             &Symbol::new(&env, "get_owner"),
             vec![&env, commitment.into_val(&env)],
         );
-        let owner =
-            owner.unwrap_or_else(|| panic_with_error!(&env, EscrowError::CommitmentNotRegistered));
+        let owner = shared_auth::unwrap_or_panic(&env, owner, EscrowError::CommitmentNotRegistered);
 
         // 3. Authenticate: the resolved owner must sign this transaction.
-        owner.require_auth();
+        shared_auth::require_address_auth(&owner);
 
         // 4. Existence guard: reject if a vault already exists for this commitment.
         if read_vault_config(&env, &commitment).is_some() {
@@ -124,7 +127,7 @@ impl EscrowContract {
         let config = read_vault_config(&env, &commitment).ok_or(EscrowError::VaultNotFound)?;
         let mut state = read_vault_state(&env, &commitment).ok_or(EscrowError::VaultNotFound)?;
 
-        config.owner.require_auth();
+        require_vault_owner(&config);
 
         if !state.is_active {
             return Err(EscrowError::VaultInactive);
@@ -165,12 +168,10 @@ impl EscrowContract {
             panic_with_error!(&env, EscrowError::InvalidAmount);
         }
 
-        let config = read_vault_config(&env, &commitment)
-            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::VaultNotFound));
-        let mut state = read_vault_state(&env, &commitment)
-            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::VaultNotFound));
+        let config = read_vault_config_or_panic(&env, &commitment);
+        let mut state = read_vault_state_or_panic(&env, &commitment);
 
-        config.owner.require_auth();
+        require_vault_owner(&config);
 
         if !state.is_active {
             panic_with_error!(&env, EscrowError::VaultInactive);
@@ -237,7 +238,7 @@ impl EscrowContract {
 
         // 3. Authenticate caller as owner of from vault
         // Host-level authentication. Panics with host error if unauthorized.
-        config.owner.require_auth();
+        require_vault_owner(&config);
 
         // 4. Reject if vault is inactive
         if !state.is_active {
@@ -340,7 +341,7 @@ impl EscrowContract {
     pub fn cancel_vault(env: Env, commitment: BytesN<32>) -> Result<(), EscrowError> {
         // 1) Load vault config + authenticate as owner.
         let config = read_vault_config(&env, &commitment).ok_or(EscrowError::VaultNotFound)?;
-        config.owner.require_auth();
+        require_vault_owner(&config);
 
         // 2) Load vault mutable state.
         let mut state = read_vault_state(&env, &commitment).ok_or(EscrowError::VaultNotFound)?;
@@ -412,7 +413,7 @@ impl EscrowContract {
         let config = read_vault_config(&env, &from).ok_or(EscrowError::VaultNotFound)?;
 
         // 3. Authenticate caller as owner of from vault
-        config.owner.require_auth();
+        require_vault_owner(&config);
 
         // 4. Generate AutoPay rule ID
         let rule_id = increment_auto_pay_id(&env)?;
@@ -454,9 +455,8 @@ impl EscrowContract {
     /// Only the registered owner of the `from` vault may cancel its rules.
     pub fn cancel_auto_pay(env: Env, from: BytesN<32>, rule_id: u32) {
         // 1. Resolve and authenticate the vault owner.
-        let config = read_vault_config(&env, &from)
-            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::VaultNotFound));
-        config.owner.require_auth();
+        let config = read_vault_config_or_panic(&env, &from);
+        require_vault_owner(&config);
 
         // 2. Confirm the rule exists before deleting it.
         if read_auto_pay(&env, &from, rule_id).is_none() {
@@ -487,8 +487,11 @@ impl EscrowContract {
     /// - Panics with `InsufficientBalance` if the vault balance is less than the payment amount.
     pub fn trigger_auto_pay(env: Env, from: BytesN<32>, rule_id: u32) {
         // 1. Load AutoPay rule via composite key
-        let mut auto_pay = read_auto_pay(&env, &from, rule_id)
-            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::AutoPayNotFound));
+        let mut auto_pay = shared_auth::unwrap_or_panic(
+            &env,
+            read_auto_pay(&env, &from, rule_id),
+            EscrowError::AutoPayNotFound,
+        );
 
         // 2. Check if interval has elapsed
         let current_time = env.ledger().timestamp();
@@ -499,8 +502,7 @@ impl EscrowContract {
         }
 
         // 3. Load vault state, verify the vault is active before checking balance.
-        let mut state = read_vault_state(&env, &from)
-            .unwrap_or_else(|| panic_with_error!(&env, EscrowError::VaultNotFound));
+        let mut state = read_vault_state_or_panic(&env, &from);
 
         // Reject if the source vault was cancelled.
         if !state.is_active {
@@ -622,7 +624,29 @@ impl EscrowContract {
 /// Returns the owner address of the vault identified by `commitment`, panicking
 /// with `VaultNotFound` if no vault config exists.
 fn resolve(env: &Env, commitment: &BytesN<32>) -> Address {
-    let config = read_vault_config(env, commitment)
-        .unwrap_or_else(|| panic_with_error!(env, EscrowError::VaultNotFound));
+    let config = read_vault_config_or_panic(env, commitment);
     config.owner
+}
+
+/// Loads a vault configuration or panics if the vault does not exist.
+fn read_vault_config_or_panic(env: &Env, commitment: &BytesN<32>) -> VaultConfig {
+    shared_auth::unwrap_or_panic(
+        env,
+        read_vault_config(env, commitment),
+        EscrowError::VaultNotFound,
+    )
+}
+
+/// Loads vault state or panics if the vault does not exist.
+fn read_vault_state_or_panic(env: &Env, commitment: &BytesN<32>) -> VaultState {
+    shared_auth::unwrap_or_panic(
+        env,
+        read_vault_state(env, commitment),
+        EscrowError::VaultNotFound,
+    )
+}
+
+/// Requires authorization from the vault owner.
+fn require_vault_owner(config: &VaultConfig) {
+    shared_auth::require_address_auth(&config.owner);
 }

--- a/onchain/contracts/escrow_contract/src/storage.rs
+++ b/onchain/contracts/escrow_contract/src/storage.rs
@@ -1,11 +1,14 @@
 use crate::errors::EscrowError;
 use crate::types::{AutoPay, DataKey, LegacyVault, ScheduledPayment, VaultConfig, VaultState};
+use shared::storage as shared_storage;
 use soroban_sdk::{Address, BytesN, Env};
 
 /// TTL constants for persistent storage entries.
 /// Bump amount: ~30 days (at ~5s per ledger close).
+#[allow(dead_code)]
 pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
 /// Lifetime threshold: ~7 days — entries are extended when remaining TTL drops below this.
+#[allow(dead_code)]
 pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 
 /// Reads a vault's immutable configuration from persistent storage.
@@ -13,11 +16,12 @@ pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 /// Checks the new `VaultConfig` key first; if absent, falls back to the legacy `Vault` key and
 /// projects the combined record into a `VaultConfig` for backward compatibility.
 pub fn read_vault_config(env: &Env, commitment: &BytesN<32>) -> Option<VaultConfig> {
-    let storage = env.storage().persistent();
-    if let Some(config) = storage.get(&DataKey::VaultConfig(commitment.clone())) {
+    let key = DataKey::VaultConfig(commitment.clone());
+    if let Some(config) = shared_storage::get_persistent(env, &key) {
         return Some(config);
     }
-    let legacy: LegacyVault = storage.get(&DataKey::Vault(commitment.clone()))?;
+    let legacy: LegacyVault =
+        shared_storage::get_persistent(env, &DataKey::Vault(commitment.clone()))?;
     Some(VaultConfig {
         owner: legacy.owner,
         token: legacy.token,
@@ -28,12 +32,7 @@ pub fn read_vault_config(env: &Env, commitment: &BytesN<32>) -> Option<VaultConf
 /// Writes a vault's immutable configuration to persistent storage.
 pub fn write_vault_config(env: &Env, commitment: &BytesN<32>, config: &VaultConfig) {
     let key = DataKey::VaultConfig(commitment.clone());
-    env.storage().persistent().set(&key, config);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, config);
 }
 
 /// Reads a vault's mutable state from persistent storage.
@@ -41,11 +40,12 @@ pub fn write_vault_config(env: &Env, commitment: &BytesN<32>, config: &VaultConf
 /// Checks the new `VaultState` key first; if absent, falls back to the legacy `Vault` key and
 /// projects the combined record into a `VaultState` for backward compatibility.
 pub fn read_vault_state(env: &Env, commitment: &BytesN<32>) -> Option<VaultState> {
-    let storage = env.storage().persistent();
-    if let Some(state) = storage.get(&DataKey::VaultState(commitment.clone())) {
+    let key = DataKey::VaultState(commitment.clone());
+    if let Some(state) = shared_storage::get_persistent(env, &key) {
         return Some(state);
     }
-    let legacy: LegacyVault = storage.get(&DataKey::Vault(commitment.clone()))?;
+    let legacy: LegacyVault =
+        shared_storage::get_persistent(env, &DataKey::Vault(commitment.clone()))?;
     Some(VaultState {
         balance: legacy.balance,
         is_active: legacy.is_active,
@@ -55,12 +55,7 @@ pub fn read_vault_state(env: &Env, commitment: &BytesN<32>) -> Option<VaultState
 /// Writes a vault's mutable state to persistent storage.
 pub fn write_vault_state(env: &Env, commitment: &BytesN<32>, state: &VaultState) {
     let key = DataKey::VaultState(commitment.clone());
-    env.storage().persistent().set(&key, state);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, state);
 }
 
 /// Increments the global payment counter and returns the previous ID.
@@ -68,44 +63,31 @@ pub fn write_vault_state(env: &Env, commitment: &BytesN<32>, state: &VaultState)
 /// ### Errors
 /// - Returns `EscrowError::PaymentCounterOverflow` if the counter reaches `u32::MAX`.
 pub fn increment_payment_id(env: &Env) -> Result<u32, EscrowError> {
-    let id: u32 = env
-        .storage()
-        .instance()
-        .get(&DataKey::PaymentCounter)
-        .unwrap_or(0);
+    let id: u32 = shared_storage::get_instance(env, &DataKey::PaymentCounter).unwrap_or(0);
 
     let next = id
         .checked_add(1)
         .ok_or(EscrowError::PaymentCounterOverflow)?;
 
-    env.storage()
-        .instance()
-        .set(&DataKey::PaymentCounter, &next);
+    shared_storage::set_instance(env, &DataKey::PaymentCounter, &next);
 
     Ok(id)
 }
 
 /// Reads the Registration contract address from instance storage.
 pub fn read_registration_contract(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&DataKey::RegistrationContract)
+    shared_storage::get_instance(env, &DataKey::RegistrationContract)
 }
 
 /// Writes the Registration contract address to instance storage.
 pub fn write_registration_contract(env: &Env, address: &Address) {
-    env.storage()
-        .instance()
-        .set(&DataKey::RegistrationContract, address);
+    shared_storage::set_instance(env, &DataKey::RegistrationContract, address);
 }
 
 /// Records a new scheduled payment in persistent storage.
 pub fn write_scheduled_payment(env: &Env, id: u32, payment: &ScheduledPayment) {
     let key = DataKey::ScheduledPayment(id);
-    env.storage().persistent().set(&key, payment);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, payment);
 }
 
 /// Increments the global auto-pay counter and returns the previous ID.
@@ -113,19 +95,13 @@ pub fn write_scheduled_payment(env: &Env, id: u32, payment: &ScheduledPayment) {
 /// ### Errors
 /// - Returns `EscrowError::AutoPayCounterOverflow` if the counter reaches `u32::MAX`.
 pub fn increment_auto_pay_id(env: &Env) -> Result<u32, EscrowError> {
-    let id: u32 = env
-        .storage()
-        .instance()
-        .get(&DataKey::AutoPayCounter)
-        .unwrap_or(0);
+    let id: u32 = shared_storage::get_instance(env, &DataKey::AutoPayCounter).unwrap_or(0);
 
     let next = id
         .checked_add(1)
         .ok_or(EscrowError::AutoPayCounterOverflow)?;
 
-    env.storage()
-        .instance()
-        .set(&DataKey::AutoPayCounter, &next);
+    shared_storage::set_instance(env, &DataKey::AutoPayCounter, &next);
 
     Ok(id)
 }
@@ -134,28 +110,18 @@ pub fn increment_auto_pay_id(env: &Env) -> Result<u32, EscrowError> {
 ///
 /// Returns `0` when no auto-pay rules have been created yet.
 pub fn read_auto_pay_count(env: &Env) -> u32 {
-    env.storage()
-        .instance()
-        .get(&DataKey::AutoPayCounter)
-        .unwrap_or(0)
+    shared_storage::get_instance(env, &DataKey::AutoPayCounter).unwrap_or(0)
 }
 
 /// Records an auto-pay rule in persistent storage under the composite key (vault, rule_id).
 pub fn write_auto_pay(env: &Env, commitment: &BytesN<32>, rule_id: u32, auto_pay: &AutoPay) {
     let key = DataKey::AutoPay(commitment.clone(), rule_id as u64);
-    env.storage().persistent().set(&key, auto_pay);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, auto_pay);
 }
 
 /// Reads an auto-pay rule from persistent storage by vault commitment and rule ID.
 pub fn read_auto_pay(env: &Env, commitment: &BytesN<32>, rule_id: u32) -> Option<AutoPay> {
-    env.storage()
-        .persistent()
-        .get(&DataKey::AutoPay(commitment.clone(), rule_id as u64))
+    shared_storage::get_persistent(env, &DataKey::AutoPay(commitment.clone(), rule_id as u64))
 }
 
 /// Deletes an auto-pay rule from persistent storage by vault commitment and rule ID.

--- a/onchain/contracts/factory_contract/src/lib.rs
+++ b/onchain/contracts/factory_contract/src/lib.rs
@@ -12,6 +12,7 @@ mod types;
 #[cfg(test)]
 mod test;
 
+use shared::auth as shared_auth;
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, BytesN, Env};
 
 use crate::errors::FactoryError;
@@ -66,20 +67,17 @@ impl FactoryContract {
     ///
     /// O(1) - constant time storage lookups and persistence.
     pub fn deploy_username(env: Env, username_hash: BytesN<32>, owner: Address) {
-        let auction_contract = match read_auction_contract(&env) {
-            Some(address) => address,
-            None => panic_with_error!(&env, FactoryError::Unauthorized),
-        };
-        auction_contract.require_auth();
+        require_auction_contract_auth(&env);
 
         if has_username(&env, &username_hash) {
             panic_with_error!(&env, FactoryError::AlreadyDeployed);
         }
 
-        let core_contract = match read_core_contract(&env) {
-            Some(address) => address,
-            None => panic_with_error!(&env, FactoryError::CoreContractNotConfigured),
-        };
+        let core_contract = shared_auth::unwrap_or_panic(
+            &env,
+            read_core_contract(&env),
+            FactoryError::CoreContractNotConfigured,
+        );
 
         let record = UsernameRecord {
             username_hash: username_hash.clone(),
@@ -107,11 +105,7 @@ impl FactoryContract {
     /// * `username_hash` - The 32-byte hash identifying the unique username.
     /// * `new_owner` - The address that will be the new owner.
     pub fn transfer_username(env: Env, username_hash: BytesN<32>, new_owner: Address) {
-        let auction_contract = match read_auction_contract(&env) {
-            Some(address) => address,
-            None => panic_with_error!(&env, FactoryError::Unauthorized),
-        };
-        auction_contract.require_auth();
+        require_auction_contract_auth(&env);
 
         let mut record = get_username(&env, &username_hash).expect("Username not deployed");
 
@@ -193,4 +187,12 @@ impl FactoryContract {
     pub fn core_contract(env: Env) -> Option<Address> {
         read_core_contract(&env)
     }
+}
+
+/// Loads the configured auction contract and requires its authorization.
+fn require_auction_contract_auth(env: &Env) -> Address {
+    let auction_contract =
+        shared_auth::unwrap_or_panic(env, read_auction_contract(env), FactoryError::Unauthorized);
+    shared_auth::require_address_auth(&auction_contract);
+    auction_contract
 }

--- a/onchain/contracts/factory_contract/src/storage.rs
+++ b/onchain/contracts/factory_contract/src/storage.rs
@@ -1,67 +1,46 @@
+use shared::storage as shared_storage;
 use soroban_sdk::{Address, BytesN, Env};
 
 use crate::types::{DataKey, DeployConfig, UsernameRecord};
 
 /// TTL constants for persistent storage entries.
 /// Bump amount: ~30 days (at ~5s per ledger close).
+#[allow(dead_code)]
 pub(crate) const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
 /// Lifetime threshold: ~7 days — entries are extended when remaining TTL drops below this.
+#[allow(dead_code)]
 pub(crate) const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
 
 /// Persists the auction contract address in instance storage.
 pub fn set_auction_contract(env: &Env, auction_contract: &Address) {
-    env.storage()
-        .instance()
-        .set(&DataKey::AuctionContract, auction_contract);
+    shared_storage::set_instance(env, &DataKey::AuctionContract, auction_contract);
 }
 
 /// Returns the configured auction contract address, or `None` if unset.
 pub fn get_auction_contract(env: &Env) -> Option<Address> {
-    env.storage()
-        .instance()
-        .get::<DataKey, Address>(&DataKey::AuctionContract)
+    shared_storage::get_instance(env, &DataKey::AuctionContract)
 }
 
 /// Persists the core contract address in instance storage.
 pub fn set_core_contract(env: &Env, core_contract: &Address) {
-    env.storage()
-        .instance()
-        .set(&DataKey::CoreContract, core_contract);
+    shared_storage::set_instance(env, &DataKey::CoreContract, core_contract);
 }
 
 /// Returns the configured core contract address, or `None` if unset.
 pub fn get_core_contract(env: &Env) -> Option<Address> {
-    env.storage()
-        .instance()
-        .get::<DataKey, Address>(&DataKey::CoreContract)
+    shared_storage::get_instance(env, &DataKey::CoreContract)
 }
 
 /// Stores a username record in persistent storage, extending its TTL.
 pub fn set_username(env: &Env, hash: &BytesN<32>, record: &UsernameRecord) {
     let key = DataKey::Username(hash.clone());
-    env.storage().persistent().set(&key, record);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, record);
 }
 
 /// Returns the username record for the given hash, or `None` if not registered.
 pub fn get_username(env: &Env, hash: &BytesN<32>) -> Option<UsernameRecord> {
     let key = DataKey::Username(hash.clone());
-    let record = env
-        .storage()
-        .persistent()
-        .get::<DataKey, UsernameRecord>(&key);
-    if record.is_some() {
-        env.storage().persistent().extend_ttl(
-            &key,
-            PERSISTENT_LIFETIME_THRESHOLD,
-            PERSISTENT_BUMP_AMOUNT,
-        );
-    }
-    record
+    shared_storage::get_persistent_with_ttl(env, &key)
 }
 
 /// Returns `true` if a username record exists for the given hash.
@@ -74,19 +53,12 @@ pub fn has_username(env: &Env, hash: &BytesN<32>) -> bool {
 /// Returns the deploy configuration, or `None` if not set.
 #[allow(dead_code)]
 pub fn get_config(env: &Env) -> Option<DeployConfig> {
-    env.storage()
-        .persistent()
-        .get::<DataKey, DeployConfig>(&DataKey::Config)
+    shared_storage::get_persistent(env, &DataKey::Config)
 }
 
 /// Persists the deploy configuration in persistent storage, extending its TTL.
 #[allow(dead_code)]
 pub fn set_config(env: &Env, config: &DeployConfig) {
     let key = DataKey::Config;
-    env.storage().persistent().set(&key, config);
-    env.storage().persistent().extend_ttl(
-        &key,
-        PERSISTENT_LIFETIME_THRESHOLD,
-        PERSISTENT_BUMP_AMOUNT,
-    );
+    shared_storage::set_persistent(env, &key, config);
 }

--- a/onchain/shared/src/lib.rs
+++ b/onchain/shared/src/lib.rs
@@ -1,3 +1,109 @@
 #![no_std]
 
 pub mod errors;
+
+/// Shared authorization and panic helpers for onchain contracts.
+pub mod auth {
+    use soroban_sdk::{Address, Env, Error};
+
+    /// Requires auth from the provided address.
+    pub fn require_address_auth(address: &Address) {
+        address.require_auth();
+    }
+
+    /// Returns the value or panics with the provided contract error.
+    pub fn unwrap_or_panic<T, E>(env: &Env, value: Option<T>, error: E) -> T
+    where
+        E: Copy + Into<Error>,
+    {
+        value.unwrap_or_else(|| env.panic_with_error(error))
+    }
+
+    /// Requires the caller to authorize and match the expected owner.
+    pub fn require_matching_auth<E>(env: &Env, caller: &Address, owner: &Address, error: E)
+    where
+        E: Copy + Into<Error>,
+    {
+        caller.require_auth();
+        if caller != owner {
+            env.panic_with_error(error);
+        }
+    }
+}
+
+/// Shared storage helpers for persistent TTL handling.
+pub mod storage {
+    use core::fmt::Debug;
+
+    use soroban_sdk::{Env, IntoVal, TryFromVal, Val};
+
+    /// Bump amount: ~30 days (at ~5s per ledger close).
+    pub const PERSISTENT_BUMP_AMOUNT: u32 = 518_400;
+    /// Lifetime threshold: ~7 days — entries are extended when remaining TTL drops below this.
+    pub const PERSISTENT_LIFETIME_THRESHOLD: u32 = 120_960;
+
+    /// Extends the TTL for a persistent storage key using the shared policy.
+    pub fn bump_persistent<K>(env: &Env, key: &K)
+    where
+        K: IntoVal<Env, Val>,
+    {
+        env.storage().persistent().extend_ttl(
+            key,
+            PERSISTENT_LIFETIME_THRESHOLD,
+            PERSISTENT_BUMP_AMOUNT,
+        );
+    }
+
+    /// Writes a persistent value and bumps its TTL.
+    pub fn set_persistent<K, V>(env: &Env, key: &K, value: &V)
+    where
+        K: IntoVal<Env, Val>,
+        V: IntoVal<Env, Val>,
+    {
+        env.storage().persistent().set(key, value);
+        bump_persistent(env, key);
+    }
+
+    /// Reads a persistent value.
+    pub fn get_persistent<K, V>(env: &Env, key: &K) -> Option<V>
+    where
+        V::Error: Debug,
+        K: IntoVal<Env, Val>,
+        V: TryFromVal<Env, Val>,
+    {
+        env.storage().persistent().get(key)
+    }
+
+    /// Reads a persistent value and bumps its TTL if present.
+    pub fn get_persistent_with_ttl<K, V>(env: &Env, key: &K) -> Option<V>
+    where
+        V::Error: Debug,
+        K: IntoVal<Env, Val>,
+        V: TryFromVal<Env, Val>,
+    {
+        let value = env.storage().persistent().get(key);
+        if value.is_some() {
+            bump_persistent(env, key);
+        }
+        value
+    }
+
+    /// Reads an instance value.
+    pub fn get_instance<K, V>(env: &Env, key: &K) -> Option<V>
+    where
+        V::Error: Debug,
+        K: IntoVal<Env, Val>,
+        V: TryFromVal<Env, Val>,
+    {
+        env.storage().instance().get(key)
+    }
+
+    /// Writes an instance value.
+    pub fn set_instance<K, V>(env: &Env, key: &K, value: &V)
+    where
+        K: IntoVal<Env, Val>,
+        V: IntoVal<Env, Val>,
+    {
+        env.storage().instance().set(key, value);
+    }
+}


### PR DESCRIPTION

Closes #391

## Summary
- extract shared authorization helpers for repeated owner/auth checks across core, escrow, factory, and auction contracts
- centralize persistent and instance storage helpers in `onchain/shared`
- replace duplicated storage access and TTL bump boilerplate while keeping contract interfaces stable

## Why
The onchain contracts repeated ownership validation, auth gates, storage lookups, and TTL handling in multiple modules. This refactor reduces duplication and makes the contracts easier to review and maintain before deployment.

## What changed
- added shared auth helpers and shared storage helpers in `onchain/shared`
- updated core contract modules to reuse shared owner lookup, auth, and persistent storage helpers
- updated escrow, factory, and auction contracts to reuse the same helper patterns
- kept external contract behavior and interfaces stable
- added the small helper wrappers needed to keep business logic readable

## Validation
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
