### PR TITLE
fix: resolve backend merge conflicts from PR #403

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,5 +1,4 @@
 {
-
   "name": "backend",
   "version": "0.0.1",
   "description": "",
@@ -19,6 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:unit": "jest --testPathPattern=keeper",
     "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js",
     "migration:generate": "npm run typeorm -- migration:generate -d src/database/data-source.ts",
     "migration:run": "npm run typeorm -- migration:run -d src/database/data-source.ts",
@@ -29,7 +29,9 @@
     "@nestjs/config": "^4.0.4",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^4.0.0",
     "@nestjs/typeorm": "^11.0.1",
+    "@prisma/client": "^6.0.0",
     "@stellar/stellar-sdk": "^15.0.1",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.15.1",
@@ -55,6 +57,7 @@
     "globals": "^16.0.0",
     "jest": "^30.0.0",
     "prettier": "^3.4.2",
+    "prisma": "^6.0.0",
     "source-map-support": "^0.5.21",
     "supertest": "^7.0.0",
     "ts-jest": "^29.2.5",
@@ -63,53 +66,16 @@
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.20.0"
-
-  "name": "alien-protocol-backend",
-  "version": "0.0.1",
-  "private": true,
-  "scripts": {
-    "build": "tsc",
-    "test": "jest",
-    "test:unit": "jest --testPathPattern=keeper"
-  },
-  "dependencies": {
-    "@nestjs/common": "^10.3.0",
-    "@nestjs/config": "^3.1.0",
-    "@nestjs/core": "^10.3.0",
-    "@nestjs/schedule": "^4.0.0",
-    "@nestjs/typeorm": "^10.0.0",
-    "@stellar/stellar-sdk": "^11.0.0",
-    "reflect-metadata": "^0.2.0",
-    "rxjs": "^7.8.0",
-    "sqlite3": "^5.1.6",
-    "typeorm": "^0.3.17"
-  },
-  "devDependencies": {
-    "@nestjs/testing": "^10.3.0",
-    "@types/jest": "^29.5.0",
-    "@types/node": "^20.0.0",
-    "jest": "^29.7.0",
-    "ts-jest": "^29.1.0",
-    "typescript": "^5.0.0"
-
   },
   "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
+    "moduleFileExtensions": ["js", "json", "ts"],
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {
       "^.+\\.(t|j)s$": "ts-jest"
     },
-
-    "collectCoverageFrom": [
-      "**/*.(t|j)s"
-    ],
+    "collectCoverageFrom": ["**/*.(t|j)s"],
     "coverageDirectory": "../coverage",
-
     "testEnvironment": "node"
   }
 }

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,41 +1,23 @@
 import { Module } from '@nestjs/common';
-
-import { DatabaseModule } from './database/database.module';
+import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { ConfigModule } from './config/config.module';
-import { ConfigService } from './config/config.service';
+import { DatabaseModule } from './database/database.module';
+import { KeeperModule } from './keeper/keeper.module';
 import { StellarModule } from './stellar/stellar.module';
+import { VaultModule } from './vault/vault.module';
 
 @Module({
   imports: [
     ConfigModule,
     DatabaseModule,
+    ScheduleModule.forRoot(),
+    KeeperModule,
     StellarModule,
+    VaultModule,
   ],
   controllers: [AppController],
-
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { ScheduleModule } from '@nestjs/schedule';
-import { KeeperModule } from './keeper/keeper.module';
-
-@Module({
-  imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
-    ScheduleModule.forRoot(),
-    TypeOrmModule.forRootAsync({
-      imports: [ConfigModule],
-      useFactory: (configService: ConfigService) => ({
-        type: 'sqlite',
-        database: configService.get<string>('DATABASE_URL') || './data.sqlite',
-        entities: [__dirname + '/**/*.entity{.ts,.js}'],
-        synchronize: configService.get<string>('TYPEORM_SYNCHRONIZE') === 'true',
-      }),
-      inject: [ConfigService],
-    }),
-    KeeperModule,
-  ],
-
+  providers: [AppService],
 })
 export class AppModule {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,22 +1,15 @@
 import { NestFactory } from '@nestjs/core';
-p
 import { ValidationPipe } from '@nestjs/common';
-import { AppModule } from './app.module';
-
-async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe({
-    whitelist: true,
-    transform: true,
-    forbidNonWhitelisted: true,
-  }));
-  await app.listen(process.env.PORT ?? 3000);
-
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   try {
     const app = await NestFactory.create(AppModule);
+    app.useGlobalPipes(new ValidationPipe({
+      whitelist: true,
+      transform: true,
+      forbidNonWhitelisted: true,
+    }));
     const port = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;
     await app.listen(port);
   } catch (error) {
@@ -24,6 +17,5 @@ async function bootstrap() {
     console.error(`Failed to start application: ${message}`);
     process.exit(1);
   }
-
 }
 bootstrap();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,41 +1,21 @@
 {
   "compilerOptions": {
-
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "resolvePackageJsonExports": true,
-    "esModuleInterop": true,
-    "isolatedModules": true,
-
     "module": "commonjs",
-
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-
-    "target": "ES2023",
-
     "target": "ES2021",
-
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
-
     "strictNullChecks": true,
-    "forceConsistentCasingInFileNames": true,
     "noImplicitAny": true,
     "strictBindCallApply": true,
-    "noFallthroughCasesInSwitch": true
-
-    "strictNullChecks": false,
-    "noImplicitAny": false,
-    "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": true,
-    "noFallthroughCasesInSwitch": false
-
+    "noFallthroughCasesInSwitch": true
   }
 }


### PR DESCRIPTION
## Problem
Four backend files were corrupted — two conflicting versions concatenated without conflict markers, producing invalid TypeScript and JSON.

Caused by PR #403 (keeper/schedule setup) landing without being rebased against PRs #425/#426 (vault API + TypeORM schema).

## Changes
- `package.json` — NestJS v11 deps, added `@nestjs/schedule`, `@prisma/client`, jest config
- `app.module.ts` — unified module registering all feature modules
- `main.ts` — `ValidationPipe` + try/catch error handling + `parseInt` port parsing
- `tsconfig.json` — `commonjs`, `ES2021`, strict compiler options

Closes #403

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced database ORM integration for data persistence.
  * Added task scheduling capability to the application.

* **Tests**
  * Added unit testing script to the development workflow.

* **Chores**
  * Consolidated and simplified application bootstrap process.
  * Cleaned up TypeScript compiler configuration and module structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->