### PR TITLE
test: add unit tests for CoreContract update_smt_root, EscrowContract initialize, and FactoryContract configure

### DIFF
--- a/onchain/contracts/core_contract/src/test.rs
+++ b/onchain/contracts/core_contract/src/test.rs
@@ -1652,3 +1652,71 @@ fn test_get_created_at_unchanged_after_transfer() {
 
     assert_eq!(client.get_created_at(&hash), Some(1_000_000u64));
 }
+
+// ── update_smt_root dedicated unit tests ──────────────────────────────────────
+
+#[test]
+fn test_update_smt_root_admin_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
+
+    let root = BytesN::from_array(&env, &[50u8; 32]);
+    client.update_smt_root(&root);
+
+    assert_eq!(client.get_smt_root(), root);
+}
+
+#[test]
+fn test_update_smt_root_stores_correct_value() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
+
+    let root_a = BytesN::from_array(&env, &[52u8; 32]);
+    let root_b = BytesN::from_array(&env, &[53u8; 32]);
+
+    client.update_smt_root(&root_a);
+    assert_eq!(client.get_smt_root(), root_a);
+
+    client.update_smt_root(&root_b);
+    assert_eq!(client.get_smt_root(), root_b);
+}
+
+#[test]
+fn test_update_smt_root_non_admin_rejected() {
+    let env = Env::default();
+    let (contract_id, _) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let root = BytesN::from_array(&env, &[54u8; 32]);
+
+    env.as_contract(&contract_id, || {
+        crate::storage::set_owner(&env, &owner);
+    });
+
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_smt_root",
+            args: (root.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = env.try_invoke_contract::<(), Error>(
+        &contract_id,
+        &Symbol::new(&env, "update_smt_root"),
+        (root,).into_val(&env),
+    );
+
+    assert!(result.is_err());
+}

--- a/onchain/contracts/escrow_contract/src/test.rs
+++ b/onchain/contracts/escrow_contract/src/test.rs
@@ -1767,3 +1767,39 @@ fn test_is_vault_active_returns_none_for_nonexistent_vault() {
         "nonexistent vault must return None"
     );
 }
+
+// ── initialize dedicated unit tests ───────────────────────────────────────────
+
+#[test]
+fn test_initialize_success_stores_registration_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let reg_id = env.register(MockRegistrationContract, ());
+    let escrow_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &reg_id);
+
+    env.as_contract(&escrow_id, || {
+        let stored: Option<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::RegistrationContract);
+        assert_eq!(stored, Some(reg_id.clone()));
+    });
+}
+
+#[test]
+#[should_panic]
+fn test_initialize_admin_auth_required() {
+    let env = Env::default();
+
+    let reg_id = env.register(MockRegistrationContract, ());
+    let escrow_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &reg_id);
+}

--- a/onchain/contracts/escrow_contract/src/test.rs
+++ b/onchain/contracts/escrow_contract/src/test.rs
@@ -1783,10 +1783,7 @@ fn test_initialize_success_stores_registration_contract() {
     client.initialize(&admin, &reg_id);
 
     env.as_contract(&escrow_id, || {
-        let stored: Option<Address> = env
-            .storage()
-            .instance()
-            .get(&DataKey::RegistrationContract);
+        let stored: Option<Address> = env.storage().instance().get(&DataKey::RegistrationContract);
         assert_eq!(stored, Some(reg_id.clone()));
     });
 }

--- a/onchain/contracts/factory_contract/src/test.rs
+++ b/onchain/contracts/factory_contract/src/test.rs
@@ -344,3 +344,55 @@ fn contract_getters_follow_soroban_convention() {
     assert_eq!(factory.auction_contract(), Some(auction_contract));
     assert_eq!(factory.core_contract(), Some(core_contract));
 }
+
+// ── configure dedicated unit tests ────────────────────────────────────────────
+
+#[test]
+fn test_configure_sets_auction_and_core_contracts() {
+    let env = Env::default();
+    let factory_id = env.register(FactoryContract, ());
+    let factory = FactoryContractClient::new(&env, &factory_id);
+    let auction = env.register(StubContract, ());
+    let core = env.register(StubContract, ());
+
+    factory.configure(&auction, &core);
+
+    assert_eq!(factory.auction_contract(), Some(auction));
+    assert_eq!(factory.core_contract(), Some(core));
+}
+
+#[test]
+fn test_configure_can_update_contracts() {
+    let env = Env::default();
+    let factory_id = env.register(FactoryContract, ());
+    let factory = FactoryContractClient::new(&env, &factory_id);
+    let auction_v1 = env.register(StubContract, ());
+    let core_v1 = env.register(StubContract, ());
+    let auction_v2 = env.register(StubContract, ());
+    let core_v2 = env.register(StubContract, ());
+
+    factory.configure(&auction_v1, &core_v1);
+    assert_eq!(factory.auction_contract(), Some(auction_v1));
+    assert_eq!(factory.core_contract(), Some(core_v1));
+
+    factory.configure(&auction_v2, &core_v2);
+    assert_eq!(factory.auction_contract(), Some(auction_v2));
+    assert_eq!(factory.core_contract(), Some(core_v2));
+}
+
+#[test]
+fn test_configure_unconfigured_factory_cannot_deploy() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (factory_id, _) = setup_unconfigured_factory(&env);
+    let owner = Address::generate(&env);
+    let hash = BytesN::from_array(&env, &[42u8; 32]);
+
+    let result = env.try_invoke_contract::<(), FactoryError>(
+        &factory_id,
+        &Symbol::new(&env, "deploy_username"),
+        Vec::<Val>::from_array(&env, [hash.into_val(&env), owner.into_val(&env)]),
+    );
+
+    assert_eq!(result, Err(Ok(FactoryError::Unauthorized)));
+}


### PR DESCRIPTION
# 🚀 Alien Protocol Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- Close #434

-  Close #432

- Close #433

- [x] Added tests (if necessary)
- [x] Run tests
- [x] Run formatting
- [ ] Evidence attached
- [x] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

Adds dedicated unit tests for three contracts to satisfy issues #432, #433, and #434:

**CoreContract — `update_smt_root` (#434)**
- `test_update_smt_root_admin_success`: verifies admin (via `initialize`) can update the root using the full public API flow
- `test_update_smt_root_stores_correct_value`: verifies each update overwrites the previous root and the stored value matches exactly
- `test_update_smt_root_non_admin_rejected`: verifies a non-owner attacker cannot update the root

**EscrowContract — `initialize` (#432)**
- `test_initialize_success_stores_registration_contract`: verifies the registration contract address is persisted in instance storage under `DataKey::RegistrationContract` after a successful call
- `test_initialize_admin_auth_required`: verifies the call panics when no admin authorization is provided

**FactoryContract — `configure` (#433)**
- `test_configure_sets_auction_and_core_contracts`: verifies `auction_contract()` and `core_contract()` return the configured values after a direct `configure` call (without relying on the `setup_factory` helper)
- `test_configure_can_update_contracts`: verifies `configure` can be called multiple times and always reflects the latest values
- `test_configure_unconfigured_factory_cannot_deploy`: verifies `deploy_username` returns `FactoryError::Unauthorized` when the factory has not been configured

All 156 lines of new test code pass `cargo test` with no warnings (82 core, 63 escrow, 14 factory tests).

---

## 📸 Evidence (A Loom/Cap video is required as evidence, we WON'T merge if there's no proof)

```
running 82 tests
...
test result: ok. 82 passed; 0 failed; 0 ignored  (core_contract)

running 63 tests
...
test result: ok. 63 passed; 0 failed; 0 ignored  (escrow_contract)

running 14 tests
...
test result: ok. 14 passed; 0 failed; 0 ignored  (factory_contract)
```

---

## ⏰ Time spent breakdown

- Code analysis & understanding contracts: ~30 min
- Implementing tests: ~20 min
- Validating with `cargo test`: ~5 min

---

## 🌌 Comments

No production code was changed. Only test files were modified:
- `onchain/contracts/core_contract/src/test.rs`
- `onchain/contracts/escrow_contract/src/test.rs`
- `onchain/contracts/factory_contract/src/test.rs`

---

Thank you for contributing to Alien Protocol !!