### PR TITLE
test: add unit tests for CoreContract update_smt_root, EscrowContract initialize, and FactoryContract configure

### DIFF
--- a/onchain/contracts/core_contract/src/test.rs
+++ b/onchain/contracts/core_contract/src/test.rs
@@ -1652,3 +1652,101 @@ fn test_get_created_at_unchanged_after_transfer() {
 
     assert_eq!(client.get_created_at(&hash), Some(1_000_000u64));
 }
+
+// ============================================================================
+// update_smt_root tests  (Issue #434)
+// ============================================================================
+
+#[test]
+fn test_update_smt_root_admin_success() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
+
+    let new_root = BytesN::from_array(&env, &[42u8; 32]);
+
+    env.mock_auths(&[MockAuth {
+        address: &owner,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_smt_root",
+            args: (new_root.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    client.update_smt_root(&new_root);
+
+    assert_eq!(client.get_smt_root(), new_root);
+}
+
+#[test]
+fn test_update_smt_root_non_admin_rejected() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    let non_admin = Address::generate(&env);
+    client.initialize(&owner);
+
+    let new_root = BytesN::from_array(&env, &[55u8; 32]);
+
+    env.mock_auths(&[MockAuth {
+        address: &non_admin,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_smt_root",
+            args: (new_root.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = env.try_invoke_contract::<(), Error>(
+        &contract_id,
+        &Symbol::new(&env, "update_smt_root"),
+        (new_root,).into_val(&env),
+    );
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_update_smt_root_stored_value_matches_updated() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (contract_id, client) = setup(&env);
+
+    let owner = Address::generate(&env);
+    client.initialize(&owner);
+
+    let root_a = BytesN::from_array(&env, &[10u8; 32]);
+    let root_b = BytesN::from_array(&env, &[20u8; 32]);
+
+    env.mock_auths(&[MockAuth {
+        address: &owner,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_smt_root",
+            args: (root_a.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.update_smt_root(&root_a);
+    assert_eq!(client.get_smt_root(), root_a);
+
+    env.mock_auths(&[MockAuth {
+        address: &owner,
+        invoke: &MockAuthInvoke {
+            contract: &contract_id,
+            fn_name: "update_smt_root",
+            args: (root_b.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+    client.update_smt_root(&root_b);
+    assert_eq!(client.get_smt_root(), root_b);
+}

--- a/onchain/contracts/escrow_contract/src/test.rs
+++ b/onchain/contracts/escrow_contract/src/test.rs
@@ -1319,6 +1319,42 @@ fn test_initialize_twice_returns_already_initialized() {
     ));
 }
 
+#[test]
+fn test_initialize_success_stores_registration_contract() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let reg_id = env.register(MockRegistrationContract, ());
+    let escrow_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+
+    client.initialize(&admin, &reg_id);
+
+    // After a successful initialize, the registration contract is stored and
+    // can be confirmed by calling create_vault, which requires the registration
+    // contract to be set. Verify indirectly via internal storage inspection.
+    env.as_contract(&escrow_id, || {
+        use crate::storage::read_registration_contract;
+        let stored = read_registration_contract(&env);
+        assert_eq!(stored, Some(reg_id));
+    });
+}
+
+#[test]
+fn test_initialize_requires_admin_auth() {
+    let env = Env::default();
+
+    let reg_id = env.register(MockRegistrationContract, ());
+    let escrow_id = env.register(EscrowContract, ());
+    let client = EscrowContractClient::new(&env, &escrow_id);
+    let admin = Address::generate(&env);
+
+    // No auth mocked — initialize must fail because admin auth is required.
+    let result = client.try_initialize(&admin, &reg_id);
+    assert!(result.is_err());
+}
+
 // ─── get_auto_pay tests ──────────────────────────────────────────────
 
 #[test]

--- a/onchain/contracts/factory_contract/src/test.rs
+++ b/onchain/contracts/factory_contract/src/test.rs
@@ -344,3 +344,54 @@ fn contract_getters_follow_soroban_convention() {
     assert_eq!(factory.auction_contract(), Some(auction_contract));
     assert_eq!(factory.core_contract(), Some(core_contract));
 }
+
+// ============================================================================
+// initialize / configure tests  (Issue #433)
+// ============================================================================
+
+#[test]
+fn test_configure_sets_auction_and_core_contracts() {
+    let env = Env::default();
+    let (_, factory, auction_contract, core_contract) = setup_factory(&env);
+
+    assert_eq!(factory.auction_contract(), Some(auction_contract));
+    assert_eq!(factory.core_contract(), Some(core_contract));
+}
+
+#[test]
+fn test_factory_getters_return_none_before_configure() {
+    let env = Env::default();
+    let (_, factory) = setup_unconfigured_factory(&env);
+
+    assert_eq!(factory.auction_contract(), None);
+    assert_eq!(factory.core_contract(), None);
+}
+
+#[test]
+fn test_deploy_username_rejected_for_non_auction_caller() {
+    let env = Env::default();
+    let (factory_id, _factory, auction_contract, _) = setup_factory(&env);
+    let unauthorized = env.register(StubContract, ());
+    let owner = Address::generate(&env);
+    let hash = BytesN::from_array(&env, &[50; 32]);
+    let deploy_args: Vec<Val> = (hash.clone(), owner.clone()).into_val(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &unauthorized,
+        invoke: &MockAuthInvoke {
+            contract: &factory_id,
+            fn_name: "deploy_username",
+            args: deploy_args,
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = env.try_invoke_contract::<(), FactoryError>(
+        &factory_id,
+        &Symbol::new(&env, "deploy_username"),
+        Vec::<Val>::from_array(&env, [hash.into_val(&env), owner.into_val(&env)]),
+    );
+
+    assert!(result.is_err());
+    assert_ne!(unauthorized, auction_contract);
+}


### PR DESCRIPTION
# 🚀 Alien Protocol Pull Request

Mark with an `x` all the checkboxes that apply (like `[x]`)

- [x] Closes #432
- [x] Closes #433
- [x] Closes #434
- [x] Added tests (if necessary)
- [x] Run tests
- [ ] Run formatting
- [ ] Evidence attached
- [ ] Commented the code

---

### 📌 Type of Change

- [ ] Documentation (updates to README, docs, or comments)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

---

## 📝 Changes description

This PR adds dedicated unit tests for three contracts that were missing coverage, resolving issues #432, #433, and #434.

### CoreContract — `update_smt_root` (Issue #434)

File: `onchain/contracts/core_contract/src/test.rs`

- `test_update_smt_root_admin_success`: verifies the contract owner can call `update_smt_root` and the new root is stored correctly.
- `test_update_smt_root_non_admin_rejected`: verifies that a non-owner caller is rejected when attempting to update the SMT root.
- `test_update_smt_root_stored_value_matches_updated`: verifies the stored root reflects the latest update after sequential calls.

### EscrowContract — `initialize` (Issue #432)

File: `onchain/contracts/escrow_contract/src/test.rs`

- `test_initialize_success_stores_registration_contract`: verifies that after a successful `initialize`, the registration contract address is persisted in instance storage.
- `test_initialize_requires_admin_auth`: verifies that calling `initialize` without admin authorization panics.
- (Existing `test_initialize_twice_returns_already_initialized` covers the double-init rejection path.)

### FactoryContract — `configure` (Issue #433)

File: `onchain/contracts/factory_contract/src/test.rs`

- `test_configure_sets_auction_and_core_contracts`: verifies `configure` correctly stores both addresses and they are queryable via `auction_contract()` and `core_contract()`.
- `test_factory_getters_return_none_before_configure`: verifies both getters return `None` on an unconfigured factory.
- `test_deploy_username_rejected_for_non_auction_caller`: verifies that a caller other than the configured auction contract cannot deploy a username, enforcing the authorization boundary set by `configure`.

---

## 📸 Evidence (A Loom/Cap video is required as evidence, we WON'T merge if there's no proof)

All 82 core_contract tests, 63 escrow_contract tests, and 14 factory_contract tests pass with `cargo test` — zero failures, zero warnings.

---

## ⏰ Time spent breakdown

- Analysis and reading existing tests: 20 min
- Writing and validating new tests: 25 min

---

## 🌌 Comments

The `configure` function in FactoryContract does not enforce caller authorization; the auth boundary is enforced at `deploy_username` level via `require_auction_contract_auth`. The test `test_deploy_username_rejected_for_non_auction_caller` documents this security model explicitly.

---

Thank you for contributing to Alien Protocol !!