### PR TITLE
chore: add .env.example with all required backend variables

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,24 +1,32 @@
-# Stellar Configuration
-STELLAR_RPC_URL=https://soroban-testnet.stellar.org
-CORE_CONTRACT_ID=C...
-ESCROW_CONTRACT_ID=C...
-FACTORY_CONTRACT_ID=C...
-AUCTION_CONTRACT_ID=C...
+# --- Server Configuration ---
+PORT=3000 # The port the backend server will run on
+TYPEORM_SYNCHRONIZE=true # Auto-sync database schema (Set to false in production)
 
-# Database Configuration
+# --- Database Configuration ---
+# Individual connection parameters (used by some services)
 POSTGRES_USER=alien
 POSTGRES_PASSWORD=alienpassword
 POSTGRES_DB=alien_gateway
 POSTGRES_PORT=5432
+# Full connection string used by the TypeORM data source
 DATABASE_URL=postgres://alien:alienpassword@localhost:5432/alien_gateway
 
-# API Authentication
-API_KEYS=key1,key2,key3 # Comma-separated list of valid API keys
-
-KEEPER_ENABLED=false
-KEEPER_SECRET_KEY=
-
+# --- Stellar / Soroban Configuration ---
+# RPC endpoints for interacting with the Soroban network
+STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org 
+# Network identifier for transaction signing
 STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 
-TYPEORM_SYNCHRONIZE=true
-PORT=3000
+# --- Smart Contract IDs ---
+CORE_CONTRACT_ID=C... # The main protocol contract address
+ESCROW_CONTRACT_ID=C... # Escrow logic contract address
+FACTORY_CONTRACT_ID=C... # Factory for creating new protocol instances
+AUCTION_CONTRACT_ID=C... # Auction mechanism contract address
+
+# --- API Authentication ---
+API_KEYS=key1,key2,key3 # Comma-separated list of valid API keys for guarding routes
+
+# --- Keeper Service (Automation) ---
+KEEPER_ENABLED=false # Toggle for background automation tasks
+KEEPER_SECRET_KEY= # Private key used by the keeper to sign transactions


### PR DESCRIPTION
I have completed the audit of the backend and updated the .env.example with all required variables, including clear placeholders and descriptive comments.

Note on Build Verification: I attempted to run npm run build to verify the environment, but encountered 44 TypeScript errors and a Prisma validation error (P1012). These appear to be pre-existing issues related to dependency version mismatches (specifically Prisma 7 vs. the project schema) and are unrelated to the documentation changes. The .env.example has been verified against the source code via Select-String audits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized environment configuration file with improved inline documentation and clearer section labeling
  * Added `SOROBAN_RPC_URL` and `DATABASE_URL` configuration variables for enhanced setup flexibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

- Close #444